### PR TITLE
[SRVLOGIC-211] add script to remove modules that should not be in the productized build

### DIFF
--- a/productized/modules
+++ b/productized/modules
@@ -1,0 +1,5 @@
+pom.xml;drools-beliefs,drools-traits,drools-verifier,drools-persistence,drools-examples,drools-examples-api,drools-test-coverage,drools-scenario-simulation,drools-metric,drools-impact-analysis,drools-retediagram,drools-fastutil,kie-maven-plugin,kie-archetypes,jpmml-migration-recipe,drools-drlonyaml-parent
+kie-drl/kie-drl-implementations/pom.xml;kie-drl-kiesession-local
+kie-drl/pom.xml;kie-drl-tests,kie-drl-tests-without-index-file
+kie-dmn/pom.xml;kie-dmn-openapi,kie-dmn-tck,kie-dmn-legacy-tests,kie-dmn-trisotech,kie-dmn-signavio,kie-dmn-pmml-tests-parent,kie-dmn-xls2dmn-cli,kie-dmn-core-jsr223-jq,kie-dmn-core-jsr223,kie-dmn-ruleset2dmn-parent
+drools-quarkus-extension/pom.xml;drools-quarkus,drools-quarkus-deployment,drools-quarkus-integration-test,drools-quarkus-integration-test-hotreload,drools-quarkus-ruleunit-integration-test,drools-quarkus-quickstart-test,drools-quarkus-examples

--- a/productized/remove_modules.sh
+++ b/productized/remove_modules.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# This script expects a configuration file separated by semicolon, where the first part is the pom and the second the modules to be removed from that pom
+# It can be invoked from project root folder using: $ ./productized/remove_modules.sh ./productized/modules
+
+# fast fail
+set -e
+set -o pipefail
+
+if [ $# -lt 1 ];
+then
+  echo "$0: Missing arguments"
+  exit
+fi
+
+config_file="${1}"
+for line in `cat "$config_file"`
+do
+    pom=$(echo $line | cut -d ';' -f1)
+    modules=$(echo $line | cut -d ';' -f2)
+
+    modules_list=$(echo $modules | tr "," "\n")
+    for module in ${modules_list}
+    do
+        echo "Removing module ${module} from ${pom}"
+        sed -i "/<module>${module}<\/module/d" ${pom}
+    done
+done


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/SRVLOGIC-211

Related PRs:
- https://github.com/kiegroup/drools/pull/11
- https://github.com/kiegroup/kogito-runtimes/pull/7
- https://github.com/kiegroup/kogito-apps/pull/3
- https://github.com/kiegroup/kogito-examples/pull/3

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-main</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native</b>

 - for <b>native lts checks</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins run native-lts</b>

- for a <b>specific native lts check</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native-lts</b>
</details>

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>

<!-- TODO to uncomment if activating the quarkus-3 rewrite PR job -->
<!-- <details>
<summary>
Quarkus-3 PR check is failing ... what to do ?
</summary>
The Quarkus 3 check is applying patches from the `.ci/environments/quarkus-3/patches`.

The first patch, called `0001_before_sh.patch`, is generated from Openrewrite `.ci/environments/quarkus-3/quarkus3.yml` recipe. The patch is created to speed up the check. But it may be that some changes in the PR broke this patch.  
No panic, there is an easy way to regenerate it. You just need to comment on the PR:
```
jenkins rewrite quarkus-3
```
and it should, after some minutes (~20/30min) apply a commit on the PR with the patch regenerated.

Other patches were generated manually. If any of it fails, you will need to manually update it... and push your changes.
</details> -->