### PR TITLE
SRVLOGIC-202: Schedule apache-main sync from upstream

### DIFF
--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -1,0 +1,47 @@
+name: Sync main-apache branch with upstream/main
+
+env:
+  USERNAME: kie-ci
+  USEREMAIL: kie-ci0@redhat.com
+  UPSTREAM_REMOTE: https://github.com/apache/incubator-kie-drools.git
+  GITHUB_TOKEN: ${{ secrets.APACHE_SYNC_MIDSTREAM_TOKEN }}
+
+on:
+  schedule:
+    - cron: "0 0 * * *" # every day at midnight
+  workflow_dispatch:
+
+jobs:
+  sync-main-apache:
+    name: Sync main-apache branch
+    runs-on: ubuntu-latest
+ 
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.APACHE_SYNC_MIDSTREAM_TOKEN }}
+
+      - name: Setup git environment
+        run: |
+          git config --global user.name "$USERNAME"
+          git config --global user.email "$USEREMAIL"
+          git remote add upstream $UPSTREAM_REMOTE
+
+      - name: Fetch all
+        run: git fetch --all --tags
+
+      - name: Checkout main-apache branch
+        run: git checkout --track origin/main-apache
+
+      - name: Pull main-apache branch
+        run: git pull
+
+      - name: Merge upstream/main branch
+        run: git merge --no-edit upstream/main
+
+      - name: Push changes
+        run: git push
+
+      - name: Push last tag
+        run: git push origin $(git tag --sort=creatordate | tail -n 1)


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/SRVLOGIC-202

Description:
Set up a GitHub Action to sync our midstream main-apache branch with the upstream main branch every day.

Please note:
If approved I will change the default branch to `main` to let the CI run as scheduled.

Repository used for tests:
https://github.com/fantonangeli/drools-fantonangeli-test