### PR TITLE
[9.99.x-prod][OSL-1.32.2] [Fix apache/incubator-kie-issues#987] Add onError listener

### DIFF
--- a/kie-api/src/main/java/org/kie/api/event/process/ErrorEvent.java
+++ b/kie-api/src/main/java/org/kie/api/event/process/ErrorEvent.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.api.event.process;
+
+import org.kie.api.runtime.process.NodeInstance;
+
+/**
+ * An event when a error is thrown
+ */
+public interface ErrorEvent extends ProcessNodeEvent {
+    /**
+     * Error associated to the event
+     *
+     * @return exception
+     */
+    Exception getException();
+}

--- a/kie-api/src/main/java/org/kie/api/event/process/ProcessEventListener.java
+++ b/kie-api/src/main/java/org/kie/api/event/process/ProcessEventListener.java
@@ -116,4 +116,10 @@ public interface ProcessEventListener
      * @param event
      */
     default void onMessage(MessageEvent event) {}
+    
+    /**
+     * This listener method is invoked when an error is captured
+     * @param event
+     */
+    default void onError (ErrorEvent event) {}
 }


### PR DESCRIPTION
Merge with https://github.com/kiegroup/kogito-runtimes/pull/30 and https://github.com/kiegroup/kogito-apps/pull/17

Required to cherry-pick https://github.com/apache/incubator-kie-drools/pull/5766 for OSL 1.32.2