### PR TITLE
[RHDM-2029] Executable model doesn't report an error when duplicated …

### DIFF
--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/AbstractKieProject.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/AbstractKieProject.java
@@ -236,6 +236,8 @@ public abstract class AbstractKieProject implements KieProject {
             }
             if (compileIncludedKieBases()) {
                 addFiles( buildFilter, assets, getKieBaseModel( include ), includeModule, useFolders );
+            } else {
+                buildContext.addIncludeModule(include, includeModule);
             }
         }
 

--- a/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/BuildContext.java
+++ b/drools-compiler/src/main/java/org/drools/compiler/kie/builder/impl/BuildContext.java
@@ -15,6 +15,9 @@
 
 package org.drools.compiler.kie.builder.impl;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class BuildContext {
     private final ResultsImpl messages;
 
@@ -32,5 +35,13 @@ public class BuildContext {
 
     public boolean registerResourceToBuild(String kBaseName, String resource) {
         return true;
+    }
+
+    public void addIncludeModule(String kBaseName, InternalKieModule includeModule) {
+        // no op
+    }
+
+    public Map<String, InternalKieModule> getIncludeModules() {
+        return new HashMap<>();
     }
 }

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/CanonicalModelBuildContext.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/CanonicalModelBuildContext.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.drools.compiler.kie.builder.impl.BuildContext;
+import org.drools.compiler.kie.builder.impl.InternalKieModule;
 import org.drools.compiler.kie.builder.impl.ResultsImpl;
 
 public class CanonicalModelBuildContext extends BuildContext {
@@ -32,6 +33,8 @@ public class CanonicalModelBuildContext extends BuildContext {
 
     private final Collection<GeneratedClassWithPackage> allGeneratedPojos = new HashSet<>();
     private final Map<String, Class<?>> allCompiledClasses = new HashMap<>();
+
+    private final Map<String, InternalKieModule> includeModules = new HashMap<>();
 
     public CanonicalModelBuildContext() { }
 
@@ -80,5 +83,15 @@ public class CanonicalModelBuildContext extends BuildContext {
     private String resource2Package(String resource) {
         int pathEndPos = resource.lastIndexOf('/');
         return pathEndPos <= 0 ? "" :resource.substring(0, pathEndPos).replace('/', '.');
+    }
+
+    @Override
+    public void addIncludeModule(String kBaseName, InternalKieModule includeModule) {
+        includeModules.put(kBaseName, includeModule);
+    }
+
+    @Override
+    public Map<String, InternalKieModule> getIncludeModules() {
+        return includeModules;
     }
 }

--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/ModelBuilderImpl.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/ModelBuilderImpl.java
@@ -16,6 +16,7 @@
 
 package org.drools.modelcompiler.builder;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -29,24 +30,35 @@ import org.drools.compiler.builder.impl.KnowledgeBuilderConfigurationImpl;
 import org.drools.compiler.builder.impl.KnowledgeBuilderImpl;
 import org.drools.compiler.builder.impl.TypeDeclarationFactory;
 import org.drools.compiler.compiler.PackageRegistry;
+import org.drools.compiler.compiler.ParserError;
+import org.drools.compiler.kie.builder.impl.AbstractKieModule;
 import org.drools.compiler.kie.builder.impl.BuildContext;
+import org.drools.compiler.kie.builder.impl.InternalKieModule;
 import org.drools.compiler.lang.descr.AbstractClassTypeDeclarationDescr;
 import org.drools.compiler.lang.descr.CompositePackageDescr;
 import org.drools.compiler.lang.descr.EnumDeclarationDescr;
 import org.drools.compiler.lang.descr.GlobalDescr;
 import org.drools.compiler.lang.descr.ImportDescr;
 import org.drools.compiler.lang.descr.PackageDescr;
+import org.drools.compiler.lang.descr.RuleDescr;
 import org.drools.compiler.lang.descr.TypeDeclarationDescr;
 import org.drools.core.addon.TypeResolver;
 import org.drools.core.definitions.InternalKnowledgePackage;
 import org.drools.core.rule.ImportDeclaration;
 import org.drools.core.rule.TypeDeclaration;
 import org.drools.core.util.StringUtils;
+import org.drools.modelcompiler.CanonicalKieModule;
 import org.drools.modelcompiler.builder.errors.UnsupportedFeatureError;
 import org.drools.modelcompiler.builder.generator.DRLIdGenerator;
 import org.drools.modelcompiler.builder.generator.DrlxParseUtil;
 import org.drools.modelcompiler.builder.generator.declaredtype.POJOGenerator;
+import org.kie.api.KieBase;
+import org.kie.api.KieServices;
+import org.kie.api.builder.KieModule;
+import org.kie.api.builder.KieRepository;
 import org.kie.api.builder.ReleaseId;
+import org.kie.api.runtime.KieContainer;
+import org.kie.internal.builder.KnowledgeBuilder;
 import org.kie.internal.builder.ResultSeverity;
 
 import static com.github.javaparser.StaticJavaParser.parseImport;
@@ -302,5 +314,46 @@ public class ModelBuilderImpl<T extends PackageSources> extends KnowledgeBuilder
     @Override
     protected BuildContext createBuildContext() {
         return new CanonicalModelBuildContext();
+    }
+
+    // Overridden, because exec-model doesn't add assets of included kbase to the packageDescr
+    @Override
+    protected void validateUniqueRuleNames(final PackageDescr packageDescr) {
+        super.validateUniqueRuleNames(packageDescr);
+
+        // check for duplicated rule names in included kbase
+        Map<String, InternalKieModule> includeModules = getBuildContext().getIncludeModules();
+        List<String> ruleNamesInIncludeKBases = new ArrayList<>();
+        for (Map.Entry<String, InternalKieModule> entry : includeModules.entrySet()) {
+            String kBaseName = entry.getKey();
+            InternalKieModule includeModule = entry.getValue();
+            if (!(includeModule instanceof CanonicalKieModule)) {
+                continue;
+            }
+            CanonicalKieModule canonicalKieModule = (CanonicalKieModule) includeModule;
+            InternalKieModule internalKieModule = canonicalKieModule.getInternalKieModule();
+            if (!(internalKieModule instanceof AbstractKieModule)) {
+                continue;
+            }
+            AbstractKieModule abstractKieModule = (AbstractKieModule) internalKieModule;
+            ReleaseId internalReleaseId = abstractKieModule.getReleaseId();
+            KieServices ks = KieServices.Factory.get();
+            KieContainer kieContainer = ks.newKieContainer(internalReleaseId);
+            KieBase kieBase = kieContainer.getKieBase(kBaseName);
+            // add rule names to ruleNamesInIncludeKBases
+            kieBase.getKiePackages().stream()
+                    .filter(kPkg -> kPkg.getName().equals(packageDescr.getNamespace()))
+                    .flatMap(kPkg -> kPkg.getRules().stream())
+                    .forEach(rule -> ruleNamesInIncludeKBases.add(rule.getName()));
+        }
+        for (final RuleDescr ruleDescr : packageDescr.getRules()) {
+            if (ruleNamesInIncludeKBases.contains(ruleDescr.getName())) {
+                addBuilderResult(new ParserError(ruleDescr.getResource(),
+                                                 "Duplicate rule name: " + ruleDescr.getName(),
+                                                 ruleDescr.getLine(),
+                                                 ruleDescr.getColumn(),
+                                                 packageDescr.getNamespace()));
+            }
+        }
     }
 }

--- a/drools-test-coverage/test-compiler-integration/pom.xml
+++ b/drools-test-coverage/test-compiler-integration/pom.xml
@@ -157,7 +157,12 @@
           <artifactId>hamcrest-core</artifactId>
         </exclusion>
       </exclusions>
-    </dependency>  
+    </dependency>
+    <dependency>
+      <groupId>org.kie</groupId>
+      <artifactId>kie-ci</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/drools-test-coverage/test-compiler-integration/pom.xml
+++ b/drools-test-coverage/test-compiler-integration/pom.xml
@@ -158,11 +158,6 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <dependency>
-      <groupId>org.kie</groupId>
-      <artifactId>kie-ci</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <profiles>

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/KieBaseIncludesTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/KieBaseIncludesTest.java
@@ -20,11 +20,9 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 
-import org.drools.compiler.kie.builder.impl.InternalKieModule;
 import org.drools.core.util.FileManager;
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieUtil;
-import org.drools.testcoverage.common.util.MavenUtil;
 import org.drools.testcoverage.common.util.TestParametersUtil;
 import org.junit.After;
 import org.junit.Before;
@@ -40,7 +38,6 @@ import org.kie.api.builder.ReleaseId;
 import org.kie.api.definition.KiePackage;
 import org.kie.api.definition.rule.Rule;
 import org.kie.api.runtime.KieContainer;
-import org.kie.scanner.KieMavenRepository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -327,12 +324,7 @@ public class KieBaseIncludesTest {
                 .write("src/main/resources/rules/rules.drl", drlSub)
                 .writeKModuleXML(kmoduleContentSub);
 
-        KieBuilder kieBuilderSub = KieUtil.getKieBuilderFromKieFileSystem(kieBaseTestConfiguration, kfsSub, true);
-
-        // install "rules-sub" into maven local repository, remove it from in-memory KieRepository. Simulating kie-maven-plugin use case
-        final KieMavenRepository repository = KieMavenRepository.getKieMavenRepository();
-        repository.installArtifact(releaseIdSub, (InternalKieModule) kieBuilderSub.getKieModule(), MavenUtil.createPomXml(fileManager, releaseIdSub));
-        ks.getRepository().removeKieModule(releaseIdSub);
+        KieUtil.getKieBuilderFromKieFileSystem(kieBaseTestConfiguration, kfsSub, true);
 
         KieFileSystem kfsMain = ks.newKieFileSystem()
                 .writePomXML(pomContentMain)


### PR DESCRIPTION
…rule name with "include" kbase

**Ports** 
This PR is for 7.x
7.67.x ->

**JIRA**:
https://issues.redhat.com/browse/RHDM-2029

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-main</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native</b>

 - for <b>native lts checks</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins run native-lts</b>

- for a <b>specific native lts check</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native-lts</b>
</details>

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>

<!-- TODO to uncomment if activating the quarkus-3 rewrite PR job -->
<!-- <details>
<summary>
Quarkus-3 PR check is failing ... what to do ?
</summary>
The Quarkus 3 check is applying patches from the `.ci/environments/quarkus-3/patches`.

The first patch, called `0001_before_sh.patch`, is generated from Openrewrite `.ci/environments/quarkus-3/quarkus3.yml` recipe. The patch is created to speed up the check. But it may be that some changes in the PR broke this patch.  
No panic, there is an easy way to regenerate it. You just need to comment on the PR:
```
jenkins rewrite quarkus-3
```
and it should, after some minutes (~20/30min) apply a commit on the PR with the patch regenerated.

Other patches were generated manually. If any of it fails, you will need to manually update it... and push your changes.
</details> -->