### PR TITLE
[RHDM-2029] Executable model doesn't report an error when duplicated …

### DIFF
--- a/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/errors/PackageBuildException.java
+++ b/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/errors/PackageBuildException.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.modelcompiler.builder.errors;
+
+public class PackageBuildException extends RuntimeException {
+
+    public PackageBuildException(String message) {
+        super(message);
+    }
+}

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/KieBaseIncludesTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/integrationtests/KieBaseIncludesTest.java
@@ -16,8 +16,11 @@
 
 package org.drools.mvel.integrationtests;
 
+import java.io.IOException;
 import java.util.Collection;
+import java.util.List;
 
+import org.drools.modelcompiler.builder.errors.PackageBuildException;
 import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
 import org.drools.testcoverage.common.util.KieUtil;
 import org.drools.testcoverage.common.util.TestParametersUtil;
@@ -26,13 +29,16 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.kie.api.KieBase;
 import org.kie.api.KieServices;
+import org.kie.api.builder.KieBuilder;
 import org.kie.api.builder.KieFileSystem;
+import org.kie.api.builder.Message;
 import org.kie.api.builder.ReleaseId;
 import org.kie.api.definition.KiePackage;
 import org.kie.api.definition.rule.Rule;
 import org.kie.api.runtime.KieContainer;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 // DROOLS-1044
 @RunWith(Parameterized.class)
@@ -214,6 +220,7 @@ public class KieBaseIncludesTest {
         KieUtil.getKieBuilderFromKieFileSystem(kieBaseTestConfiguration, kfs1, true);
 
         KieContainer kc = ks.newKieContainer(releaseId1);
+        System.out.println("--- getKieBase()");
         KieBase kieBase = kc.getKieBase();
 
         // Assert the number of rules in the KieBase.
@@ -240,5 +247,91 @@ public class KieBaseIncludesTest {
             nrOfRules += rules.size();
         }
         return nrOfRules;
+    }
+
+    /**
+     * Test the inclusion of a KieBase defined in one KJAR into the KieBase of another KJAR.
+     * <p/>
+     * The 2 KieBases use the duplicate rule names, so an error should be reported
+     */
+    @Test
+    public void kieBaseIncludesCrossKJarDuplicateRuleNames_shouldReportError() throws IOException {
+
+        String pomContentMain = "<project xmlns=\"http://maven.apache.org/POM/4.0.0\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd\">\n" +
+                "<modelVersion>4.0.0</modelVersion>\n" +
+                "<groupId>org.kie</groupId>\n" +
+                "<artifactId>rules-main</artifactId>\n" +
+                "<version>1.0.0</version>\n" +
+                "<packaging>jar</packaging>\n" +
+                "<dependencies>\n" +
+                "<dependency>\n" +
+                "<groupId>org.kie</groupId>\n" +
+                "<artifactId>rules-sub</artifactId>\n" +
+                "<version>1.0.0</version>\n" +
+                "</dependency>\n" +
+                "</dependencies>\n" +
+                "</project>\n";
+
+        String kmoduleContentMain = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                "<kmodule xmlns=\"http://jboss.org/kie/6.0.0/kmodule\">\n" +
+                "<kbase name=\"kbaseMain\" equalsBehavior=\"equality\" default=\"true\" packages=\"rules\" includes=\"kbaseSub\">\n" +
+                "<ksession name=\"ksessionMain\" default=\"true\" type=\"stateful\"/>\n" +
+                "</kbase>\n" +
+                "</kmodule>";
+
+        String drlMain = "package rules\n" +
+                "\n" +
+                "rule \"RuleA\"\n" +
+                "when\n" +
+                "then\n" +
+                "System.out.println(\"Rule in KieBaseMain\");\n" +
+                "end";
+
+        String kmoduleContentSub = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                "<kmodule xmlns=\"http://jboss.org/kie/6.0.0/kmodule\">\n" +
+                "<kbase name=\"kbaseSub\" equalsBehavior=\"equality\" default=\"false\" packages=\"rules\">\n" +
+                "<ksession name=\"ksessionSub\" default=\"false\" type=\"stateful\"/>\n" +
+                "</kbase>\n" +
+                "</kmodule>";
+
+        String drlSub = "package rules\n" +
+                "\n" +
+                "rule \"RuleA\"\n" +
+                "when\n" +
+                "then\n" +
+                "System.out.println(\"Rule in KieBaseSub\");\n" +
+                "end";
+
+        KieServices ks = KieServices.Factory.get();
+        ReleaseId releaseIdSub = ks.newReleaseId("org.kie", "rules-sub", "1.0.0");
+
+        //First deploy the second KJAR on which the first one depends.
+        KieFileSystem kfsSub = ks.newKieFileSystem()
+                .generateAndWritePomXML(releaseIdSub)
+                .write("src/main/resources/rules/rules.drl", drlSub)
+                .writeKModuleXML(kmoduleContentSub);
+
+        KieUtil.getKieBuilderFromKieFileSystem(kieBaseTestConfiguration, kfsSub, true);
+
+        KieFileSystem kfsMain = ks.newKieFileSystem()
+                .writePomXML(pomContentMain)
+                .write("src/main/resources/rules/rules.drl", drlMain)
+                .writeKModuleXML(kmoduleContentMain);
+
+        KieBuilder kieBuilderMain = KieUtil.getKieBuilderFromKieFileSystem(kieBaseTestConfiguration, kfsMain, false);
+        List<Message> messages = kieBuilderMain.getResults().getMessages(Message.Level.ERROR);
+
+        if (kieBaseTestConfiguration.isExecutableModel()) {
+            ReleaseId releaseIdMain = ks.newReleaseId("org.kie", "rules-main", "1.0.0");
+            KieContainer kieContainer = ks.newKieContainer(releaseIdMain);
+            // exec-model doesn't report the error at build phase. Throws Exception on kbase build
+            assertThatThrownBy(() -> kieContainer.getKieBase())
+                    .isInstanceOf(PackageBuildException.class)
+                    .hasMessageContaining("Duplicate rule name");
+        } else {
+            // non-exec-model reports the error at build phase
+            assertThat(messages).as("Duplication error should be reported")
+                    .extracting(Message::getText).anyMatch(text -> text.contains("Duplicate rule name"));
+        }
     }
 }


### PR DESCRIPTION
…rule name with "include" kbase

**Ports** 
This PR is for 7.x
7.67.x ->

**JIRA**:
https://issues.redhat.com/browse/RHDM-2029

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-main</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native</b>

 - for <b>native lts checks</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins run native-lts</b>

- for a <b>specific native lts check</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native-lts</b>
</details>

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>

<!-- TODO to uncomment if activating the quarkus-3 rewrite PR job -->
<!-- <details>
<summary>
Quarkus-3 PR check is failing ... what to do ?
</summary>
The Quarkus 3 check is applying patches from the `.ci/environments/quarkus-3/patches`.

The first patch, called `0001_before_sh.patch`, is generated from Openrewrite `.ci/environments/quarkus-3/quarkus3.yml` recipe. The patch is created to speed up the check. But it may be that some changes in the PR broke this patch.  
No panic, there is an easy way to regenerate it. You just need to comment on the PR:
```
jenkins rewrite quarkus-3
```
and it should, after some minutes (~20/30min) apply a commit on the PR with the patch regenerated.

Other patches were generated manually. If any of it fails, you will need to manually update it... and push your changes.
</details> -->