### PR TITLE
[7.67.x-blue] Improve Import Resolver error messages to be more user friendly (#6014)

### DIFF
--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/ImportDMNResolverUtil.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/ImportDMNResolverUtil.java
@@ -74,7 +74,7 @@ public class ImportDMNResolverUtil {
         } else {
             List<T> usingNSandName = matchingDMNList.stream()
                     .filter(dmn -> idExtractor.apply(dmn).getLocalPart().equals(importModelName))
-                    .toList();
+                    .collect(Collectors.toList());
             if (usingNSandName.size() == 1) {
                 LOGGER.debug("DMN Model with name={} and namespace={} successfully imported a DMN " +
                                 "with namespace={} name={} locationURI={}, modelName={}",

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/ImportDMNResolverUtil.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/ImportDMNResolverUtil.java
@@ -24,58 +24,88 @@ import java.util.stream.Collectors;
 import javax.xml.namespace.QName;
 
 import org.kie.dmn.feel.util.Either;
+import org.kie.dmn.model.api.Definitions;
 import org.kie.dmn.model.api.Import;
 import org.kie.dmn.model.api.NamespaceConsts;
 import org.kie.dmn.model.v1_1.TImport;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ImportDMNResolverUtil {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ImportDMNResolverUtil.class);
 
     private ImportDMNResolverUtil() {
         // No constructor for util class.
     }
 
-    public static <T> Either<String, T> resolveImportDMN(Import _import, Collection<T> all, Function<T, QName> idExtractor) {
-        final String iNamespace = _import.getNamespace();
-        final String iName = _import.getName();
-        final String iModelName = _import.getAdditionalAttributes().get(TImport.MODELNAME_QNAME);
-        List<T> allInNS = all.stream()
-                             .filter(m -> idExtractor.apply(m).getNamespaceURI().equals(iNamespace))
-                             .collect(Collectors.toList());
-        if (allInNS.size() == 1) {
-            T located = allInNS.get(0);
+    public static <T> Either<String, T> resolveImportDMN(Import importElement, Collection<T> dmns, Function<T, QName> idExtractor) {
+        final String importerDMNNamespace = ((Definitions) importElement.getParent()).getNamespace();
+        final String importerDMNName = ((Definitions) importElement.getParent()).getName();
+        final String importNamespace = importElement.getNamespace();
+        final String importName = importElement.getName();
+        final String importLocationURI = importElement.getLocationURI(); // This is optional
+        final String importModelName = importElement.getAdditionalAttributes().get(TImport.MODELNAME_QNAME);
+
+        LOGGER.debug("Resolving an Import in DMN Model with name={} and namespace={}. " +
+                        "Importing a DMN model with namespace={} name={} locationURI={}, modelName={}",
+                importerDMNNamespace, importerDMNName, importNamespace, importName, importLocationURI, importModelName);
+
+        List<T> matchingDMNList = dmns.stream()
+                .filter(m -> idExtractor.apply(m).getNamespaceURI().equals(importNamespace))
+                .collect(Collectors.toList());
+        if (matchingDMNList.size() == 1) {
+            T located = matchingDMNList.get(0);
             // Check if the located DMN Model in the NS, correspond for the import `drools:modelName`. 
-            if (iModelName == null || idExtractor.apply(located).getLocalPart().equals(iModelName)) {
+            if (importModelName == null || idExtractor.apply(located).getLocalPart().equals(importModelName)) {
+                LOGGER.debug("DMN Model with name={} and namespace={} successfully imported a DMN " +
+                                "with namespace={} name={} locationURI={}, modelName={}",
+                        importerDMNNamespace, importerDMNName, importNamespace, importName, importLocationURI, importModelName);
                 return Either.ofRight(located);
             } else {
-                return Either.ofLeft(String.format("While importing DMN for namespace: %s, name: %s, modelName: %s, located within namespace only %s but does not match for the actual name",
-                                                   iNamespace, iName, iModelName,
-                                                   idExtractor.apply(located)));
+                LOGGER.error("DMN Model with name={} and namespace={} can't import a DMN with namespace={}, name={}, modelName={}, " +
+                                "located within namespace only {} but does not match for the actual modelName",
+                        importerDMNNamespace, importerDMNName, importNamespace, importName, importModelName, idExtractor.apply(located));
+                return Either.ofLeft(String.format(
+                        "DMN Model with name=%s and namespace=%s can't import a DMN with namespace=%s, name=%s, modelName=%s, " +
+                                "located within namespace only %s but does not match for the actual modelName",
+                        importerDMNNamespace, importerDMNName, importNamespace, importName, importModelName, idExtractor.apply(located)));
             }
         } else {
-            List<T> usingNSandName = allInNS.stream()
-                                            .filter(m -> idExtractor.apply(m).getLocalPart().equals(iModelName))
-                                            .collect(Collectors.toList());
+            List<T> usingNSandName = matchingDMNList.stream()
+                    .filter(dmn -> idExtractor.apply(dmn).getLocalPart().equals(importModelName))
+                    .toList();
             if (usingNSandName.size() == 1) {
+                LOGGER.debug("DMN Model with name={} and namespace={} successfully imported a DMN " +
+                                "with namespace={} name={} locationURI={}, modelName={}",
+                        importerDMNNamespace, importerDMNName, importNamespace, importName, importLocationURI, importModelName);
                 return Either.ofRight(usingNSandName.get(0));
-            } else if (usingNSandName.size() == 0) {
-                return Either.ofLeft(String.format("Could not locate required dependency while importing DMN for namespace: %s, name: %s, modelName: %s.",
-                                                   iNamespace, iName, iModelName));
+            } else if (usingNSandName.isEmpty()) {
+                LOGGER.error("DMN Model with name={} and namespace={} failed to import a DMN with namespace={} name={} locationURI={}, modelName={}.",
+                        importerDMNNamespace, importerDMNName, importNamespace, importName, importLocationURI, importModelName);
+                return Either.ofLeft(String.format(
+                        "DMN Model with name=%s and namespace=%s failed to import a DMN with namespace=%s name=%s locationURI=%s, modelName=%s. ",
+                        importerDMNNamespace, importerDMNName, importNamespace, importName, importLocationURI, importModelName));
             } else {
-                return Either.ofLeft(String.format("While importing DMN for namespace: %s, name: %s, modelName: %s, could not locate required dependency within: %s.",
-                                                   iNamespace, iName, iModelName,
-                                                   allInNS.stream().map(idExtractor).collect(Collectors.toList())));
+                LOGGER.error("DMN Model with name={} and namespace={} detected a collision ({} elements) trying to import a DMN with namespace={} name={} locationURI={}, modelName={}",
+                        importerDMNNamespace, importerDMNName, usingNSandName.size(), importNamespace, importName, importLocationURI, importModelName);
+                return Either.ofLeft(String.format(
+                        "DMN Model with name=%s and namespace=%s detected a collision trying to import a DMN with %s namespace, " +
+                                "%s name and modelName %s. There are %s DMN files with the same namespace in your project. " +
+                                "Please change the DMN namespaces and make them unique to fix this issue.",
+                        importerDMNNamespace, importerDMNName, importNamespace, importName, importModelName, usingNSandName.size()));
             }
         }
     }
 
-    public static enum ImportType {
+    public enum ImportType {
         UNKNOWN,
         DMN,
         PMML;
     }
 
-    public static ImportType whichImportType(Import _import) {
-        switch (_import.getImportType()) {
+    public static ImportType whichImportType(Import importElement) {
+        switch (importElement.getImportType()) {
             case org.kie.dmn.model.v1_1.KieDMNModelInstrumentedBase.URI_DMN:
             case "http://www.omg.org/spec/DMN1-2Alpha/20160929/MODEL":
             case org.kie.dmn.model.v1_2.KieDMNModelInstrumentedBase.URI_DMN:

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/ImportDMNResolverUtil.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/compiler/ImportDMNResolverUtil.java
@@ -49,7 +49,7 @@ public class ImportDMNResolverUtil {
 
         LOGGER.debug("Resolving an Import in DMN Model with name={} and namespace={}. " +
                         "Importing a DMN model with namespace={} name={} locationURI={}, modelName={}",
-                importerDMNNamespace, importerDMNName, importNamespace, importName, importLocationURI, importModelName);
+                importerDMNName, importerDMNNamespace, importNamespace, importName, importLocationURI, importModelName);
 
         List<T> matchingDMNList = dmns.stream()
                 .filter(m -> idExtractor.apply(m).getNamespaceURI().equals(importNamespace))
@@ -60,16 +60,16 @@ public class ImportDMNResolverUtil {
             if (importModelName == null || idExtractor.apply(located).getLocalPart().equals(importModelName)) {
                 LOGGER.debug("DMN Model with name={} and namespace={} successfully imported a DMN " +
                                 "with namespace={} name={} locationURI={}, modelName={}",
-                        importerDMNNamespace, importerDMNName, importNamespace, importName, importLocationURI, importModelName);
+                        importerDMNName, importerDMNNamespace, importNamespace, importName, importLocationURI, importModelName);
                 return Either.ofRight(located);
             } else {
                 LOGGER.error("DMN Model with name={} and namespace={} can't import a DMN with namespace={}, name={}, modelName={}, " +
                                 "located within namespace only {} but does not match for the actual modelName",
-                        importerDMNNamespace, importerDMNName, importNamespace, importName, importModelName, idExtractor.apply(located));
+                        importerDMNName, importerDMNNamespace, importNamespace, importName, importModelName, idExtractor.apply(located));
                 return Either.ofLeft(String.format(
                         "DMN Model with name=%s and namespace=%s can't import a DMN with namespace=%s, name=%s, modelName=%s, " +
                                 "located within namespace only %s but does not match for the actual modelName",
-                        importerDMNNamespace, importerDMNName, importNamespace, importName, importModelName, idExtractor.apply(located)));
+                        importerDMNName, importerDMNNamespace, importNamespace, importName, importModelName, idExtractor.apply(located)));
             }
         } else {
             List<T> usingNSandName = matchingDMNList.stream()
@@ -78,22 +78,22 @@ public class ImportDMNResolverUtil {
             if (usingNSandName.size() == 1) {
                 LOGGER.debug("DMN Model with name={} and namespace={} successfully imported a DMN " +
                                 "with namespace={} name={} locationURI={}, modelName={}",
-                        importerDMNNamespace, importerDMNName, importNamespace, importName, importLocationURI, importModelName);
+                        importerDMNName, importerDMNNamespace, importNamespace, importName, importLocationURI, importModelName);
                 return Either.ofRight(usingNSandName.get(0));
             } else if (usingNSandName.isEmpty()) {
                 LOGGER.error("DMN Model with name={} and namespace={} failed to import a DMN with namespace={} name={} locationURI={}, modelName={}.",
-                        importerDMNNamespace, importerDMNName, importNamespace, importName, importLocationURI, importModelName);
+                        importerDMNName, importerDMNNamespace, importNamespace, importName, importLocationURI, importModelName);
                 return Either.ofLeft(String.format(
                         "DMN Model with name=%s and namespace=%s failed to import a DMN with namespace=%s name=%s locationURI=%s, modelName=%s. ",
-                        importerDMNNamespace, importerDMNName, importNamespace, importName, importLocationURI, importModelName));
+                        importerDMNName, importerDMNNamespace, importNamespace, importName, importLocationURI, importModelName));
             } else {
                 LOGGER.error("DMN Model with name={} and namespace={} detected a collision ({} elements) trying to import a DMN with namespace={} name={} locationURI={}, modelName={}",
-                        importerDMNNamespace, importerDMNName, usingNSandName.size(), importNamespace, importName, importLocationURI, importModelName);
+                        importerDMNName, importerDMNNamespace, usingNSandName.size(), importNamespace, importName, importLocationURI, importModelName);
                 return Either.ofLeft(String.format(
                         "DMN Model with name=%s and namespace=%s detected a collision trying to import a DMN with %s namespace, " +
                                 "%s name and modelName %s. There are %s DMN files with the same namespace in your project. " +
                                 "Please change the DMN namespaces and make them unique to fix this issue.",
-                        importerDMNNamespace, importerDMNName, importNamespace, importName, importModelName, usingNSandName.size()));
+                        importerDMNName, importerDMNNamespace, importNamespace, importName, importModelName, usingNSandName.size()));
             }
         }
     }

--- a/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/ImportDMNResolverUtilTest.java
+++ b/kie-dmn/kie-dmn-core/src/test/java/org/kie/dmn/core/compiler/ImportDMNResolverUtilTest.java
@@ -10,10 +10,12 @@ import javax.xml.namespace.QName;
 
 import org.junit.Test;
 import org.kie.dmn.feel.util.Either;
+import org.kie.dmn.model.api.Definitions;
 import org.kie.dmn.model.api.Import;
 import org.kie.dmn.model.v1_1.TImport;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 public class ImportDMNResolverUtilTest {
 
@@ -156,6 +158,10 @@ public class ImportDMNResolverUtilTest {
             addAttributes.put(TImport.MODELNAME_QNAME, modelName);
         }
         i.setAdditionalAttributes(addAttributes);
+        final Definitions definitions = mock(Definitions.class);
+        definitions.setNamespace("ParentDMNNamespace");
+        definitions.setName("ParentDMN");
+        i.setParent(definitions);
         return i;
     }
 


### PR DESCRIPTION
Backport of https://github.com/apache/incubator-kie-drools/pull/6014

* Improved Error Messages + Logs

* dependabot.yml fixed

* dependabot.yml fixed

* Change Request

* Minor change

* Tests fixed

(cherry picked from commit ddb72c6751c6a89ea5ef187b93516303a3da7e5b)

**Thank you for submitting this pull request**

**NOTE!:** `kiegroup/drools` is maintained only for old branches e.g. `7.x`, `7.67.x`, `7.67.x-blue`.
If you are submitting a PR for `main` branch, please use `apache/incubator-kie-drools` instead.

**Ports** If a forward-port or a backport is needed, paste the forward port PR here

[link](https://www.example.com)

**JIRA**: _(please edit the JIRA link if it exists)_

[link](https://www.example.com)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* paste the link(s) from GitHub here
* link 2
* link 3 etc.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-main</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native</b>

 - for <b>native lts checks</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins run native-lts</b>

- for a <b>specific native lts check</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native-lts</b>
</details>

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>

<!-- TODO to uncomment if activating the quarkus-3 rewrite PR job -->
<!-- <details>
<summary>
Quarkus-3 PR check is failing ... what to do ?
</summary>
The Quarkus 3 check is applying patches from the `.ci/environments/quarkus-3/patches`.

The first patch, called `0001_before_sh.patch`, is generated from Openrewrite `.ci/environments/quarkus-3/quarkus3.yml` recipe. The patch is created to speed up the check. But it may be that some changes in the PR broke this patch.  
No panic, there is an easy way to regenerate it. You just need to comment on the PR:
```
jenkins rewrite quarkus-3
```
and it should, after some minutes (~20/30min) apply a commit on the PR with the patch regenerated.

Other patches were generated manually. If any of it fails, you will need to manually update it... and push your changes.
</details> -->