### PR TITLE
[SRVLOGIC-857] -- maven profile -full- is not required for pull request …

### DIFF
--- a/.github/workflows/pr-drools.yml
+++ b/.github/workflows/pr-drools.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Build Chain
         uses: kiegroup/kie-ci/.ci/actions/build-chain@main
         env:
-          BUILD_MVN_OPTS_CURRENT: -Dfull
+          BUILD_MVN_OPTS_CURRENT: ""
           MAVEN_OPTS: "-Dfile.encoding=UTF-8"
         with:
           definition-file: https://raw.githubusercontent.com/${GROUP:kiegroup}/drools/${BRANCH:main}/.ci/buildchain-config.yaml


### PR DESCRIPTION
**JIRA**: https://redhat.atlassian.net/browse/SRVLOGIC-857


<details>
<summary>
This fix should mitigate failure of GHA "Drools on: pull_request" which is currently failing for open PR: https://github.com/kiegroup/drools/pull/158/checks
</summary>
</details> 