### PR TITLE
[SRVLOGIC-857] -- maven profile -full- is not required for pull request -- Kogito Downstream 

### DIFF
--- a/.ci/buildchain-config.yaml
+++ b/.ci/buildchain-config.yaml
@@ -37,7 +37,7 @@ build:
     build-command:
       current: |
         export MVN_CMD=`bash -c "if [ '${{ env.ENABLE_DEPLOY }}' = 'true' ]; then printf 'deploy ${{ env.DEPLOY_MVN_OPTS }} ${{ env.KOGITO_RUNTIMES_DEPLOY_MVN_OPTS }}'; else printf 'install'; fi"`
-        mvn clean ${{ env.MVN_CMD }} -Dfull ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KOGITO_RUNTIMES_BUILD_MVN_OPTS }}
+        mvn clean ${{ env.MVN_CMD }} ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KOGITO_RUNTIMES_BUILD_MVN_OPTS }}
       upstream: |
         mvn clean install -Dquickly -Dfull ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.KOGITO_RUNTIMES_BUILD_MVN_OPTS_UPSTREAM }}
 


### PR DESCRIPTION
**JIRA**: https://redhat.atlassian.net/browse/SRVLOGIC-857

<details>
<summary>
This fix should mitigate failure of GHA "Kogito Downstream on: pull_request" which is currently failing for open PR: https://github.com/kiegroup/drools/pull/158/checks
</summary>
</details> 