### PR TITLE
[SRVLOGIC-888]  -- setting env_BUILD_MVN_OPTS at correct location

### DIFF
--- a/.github/workflows/pr-downstream.yml
+++ b/.github/workflows/pr-downstream.yml
@@ -30,8 +30,7 @@ jobs:
           - job_name: serverless-workflow-examples
             repository: kogito-examples
             env_KOGITO_EXAMPLES_SUBFOLDER_POM: serverless-workflow-examples/
-            env:
-              BUILD_MVN_OPTS: " -Dproductized"
+        env_BUILD_MVN_OPTS: " -Dproductized"
       fail-fast: false
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.job_name }} (${{ matrix.os }} / Java-${{ matrix.java-version }} / Maven-${{ matrix.maven-version }})


### PR DESCRIPTION
**JIRA**: https://redhat.atlassian.net/browse/SRVLOGIC-888

this fix should make the param `-Dproductized` be effective.

<details>
<summary>
On the way to make PR checks 9.105.x-prod branch, (e.g. in https://github.com/kiegroup/drools/pull/158)  passing
</summary>
</details> 