### PR TITLE
[SRVLOGIC-963] Changes for snapshots publishing.

### DIFF
--- a/.github/workflows/pr-downstream.yml
+++ b/.github/workflows/pr-downstream.yml
@@ -56,7 +56,6 @@ jobs:
           starting-project: kiegroup/${{ matrix.repository }}
           github-token: "${{ secrets.GITHUB_TOKEN }}"
         env: 
-          BUILD_MVN_OPTS: ""
           KOGITO_EXAMPLES_SUBFOLDER_POM: ${{ matrix.env_KOGITO_EXAMPLES_SUBFOLDER_POM }}
       - name: Surefire Report
         uses: kiegroup/kie-ci/.ci/actions/surefire-report@main

--- a/.github/workflows/pr-downstream.yml
+++ b/.github/workflows/pr-downstream.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore:
       - 'LICENSE'
-      - '**/.gitignore '
+      - '**/.gitignore'
       - '**.md'
       - '**.adoc'
       - '*.txt'

--- a/.github/workflows/pr-downstream.yml
+++ b/.github/workflows/pr-downstream.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore:
       - 'LICENSE'
-      - '**/.gitignore'
+      - '**/.gitignore '
       - '**.md'
       - '**.adoc'
       - '*.txt'

--- a/.github/workflows/pr-drools.yml
+++ b/.github/workflows/pr-drools.yml
@@ -44,7 +44,6 @@ jobs:
         uses: kiegroup/kie-ci/.ci/actions/build-chain@main
         env:
           MAVEN_OPTS: "-Dfile.encoding=UTF-8"
-          BUILD_MVN_OPTS: "-nsu -ntp -fae -e -Dproductized -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.count=3"
         with:
           definition-file: https://raw.githubusercontent.com/${GROUP:kiegroup}/kogito-pipelines/${BRANCH:main}/.ci/pull-request-config.yaml
           annotations-prefix: ${{ runner.os }}-${{ matrix.java-version }}/${{ matrix.maven-version }}
@@ -54,7 +53,6 @@ jobs:
         uses: kiegroup/kie-ci/.ci/actions/build-chain@main
         env:
           MAVEN_OPTS: "-Dfile.encoding=UTF-8"
-          BUILD_MVN_OPTS: "-nsu -ntp -fae -e -Dproductized -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.count=3"
         with:
           definition-file: https://raw.githubusercontent.com/${GROUP:kiegroup}/kogito-pipelines/${BRANCH:main}/.ci/pull-request-config-windows.yaml
           annotations-prefix: ${{ runner.os }}-${{ matrix.java-version }}/${{ matrix.maven-version }}

--- a/.github/workflows/pr-drools.yml
+++ b/.github/workflows/pr-drools.yml
@@ -52,7 +52,6 @@ jobs:
         if: ${{ matrix.os == 'windows-latest' }}
         uses: kiegroup/kie-ci/.ci/actions/build-chain@main
         env:
-          BUILD_MVN_OPTS_CURRENT: -Dfull
           MAVEN_OPTS: "-Dfile.encoding=UTF-8"
         with:
           definition-file: https://raw.githubusercontent.com/${GROUP:kiegroup}/kogito-pipelines/${BRANCH:main}/.ci/pull-request-config-windows.yaml

--- a/.github/workflows/pr-drools.yml
+++ b/.github/workflows/pr-drools.yml
@@ -44,6 +44,7 @@ jobs:
         uses: kiegroup/kie-ci/.ci/actions/build-chain@main
         env:
           MAVEN_OPTS: "-Dfile.encoding=UTF-8"
+          BUILD_MVN_OPTS: "-nsu -ntp -fae -e -Dproductized -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.count=3"
         with:
           definition-file: https://raw.githubusercontent.com/${GROUP:kiegroup}/kogito-pipelines/${BRANCH:main}/.ci/pull-request-config.yaml
           annotations-prefix: ${{ runner.os }}-${{ matrix.java-version }}/${{ matrix.maven-version }}
@@ -53,6 +54,7 @@ jobs:
         uses: kiegroup/kie-ci/.ci/actions/build-chain@main
         env:
           MAVEN_OPTS: "-Dfile.encoding=UTF-8"
+          BUILD_MVN_OPTS: "-nsu -ntp -fae -e -Dproductized -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.count=3"
         with:
           definition-file: https://raw.githubusercontent.com/${GROUP:kiegroup}/kogito-pipelines/${BRANCH:main}/.ci/pull-request-config-windows.yaml
           annotations-prefix: ${{ runner.os }}-${{ matrix.java-version }}/${{ matrix.maven-version }}

--- a/bom/drools-bom/pom.xml
+++ b/bom/drools-bom/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-core-bom</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../kie-core-bom/pom.xml</relativePath>
   </parent>
 

--- a/bom/kie-core-bom/pom.xml
+++ b/bom/kie-core-bom/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/bom/kie-dmn-bom/pom.xml
+++ b/bom/kie-dmn-bom/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-core-bom</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../kie-core-bom/pom.xml</relativePath>
   </parent>
 

--- a/bom/kie-efesto-bom/pom.xml
+++ b/bom/kie-efesto-bom/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-core-bom</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../kie-core-bom/pom.xml</relativePath>
   </parent>
 

--- a/bom/kie-pmml-bom/pom.xml
+++ b/bom/kie-pmml-bom/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-core-bom</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../kie-core-bom/pom.xml</relativePath>
   </parent>
 

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>drools-parent</artifactId>
         <groupId>org.kie</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>drools-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-alphanetwork-compiler/pom.xml
+++ b/drools-alphanetwork-compiler/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-base/pom.xml
+++ b/drools-base/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-beliefs/pom.xml
+++ b/drools-beliefs/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-commands/pom.xml
+++ b/drools-commands/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>drools-build-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
         <relativePath>../build-parent/pom.xml</relativePath>
     </parent>
 

--- a/drools-compiler/pom.xml
+++ b/drools-compiler/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-core/pom.xml
+++ b/drools-core/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-decisiontables/pom.xml
+++ b/drools-decisiontables/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-distribution/pom.xml
+++ b/drools-distribution/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-docs/pom.xml
+++ b/drools-docs/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-drl/drools-drl-ast/pom.xml
+++ b/drools-drl/drools-drl-ast/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-drl</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <groupId>org.drools</groupId>

--- a/drools-drl/drools-drl-extensions/pom.xml
+++ b/drools-drl/drools-drl-extensions/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.drools</groupId>
         <artifactId>drools-drl</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <groupId>org.drools</groupId>

--- a/drools-drl/drools-drl-parser-tests/pom.xml
+++ b/drools-drl/drools-drl-parser-tests/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.drools</groupId>
         <artifactId>drools-drl</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <groupId>org.drools</groupId>

--- a/drools-drl/drools-drl-parser/pom.xml
+++ b/drools-drl/drools-drl-parser/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.drools</groupId>
         <artifactId>drools-drl</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <groupId>org.drools</groupId>

--- a/drools-drl/pom.xml
+++ b/drools-drl/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-drlonyaml-parent/drools-drlonyaml-cli-tests/pom.xml
+++ b/drools-drlonyaml-parent/drools-drlonyaml-cli-tests/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-drlonyaml-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>drools-drlonyaml-cli-tests</artifactId>
   <name>Drools :: DRL on YAML :: CLI tests</name>

--- a/drools-drlonyaml-parent/drools-drlonyaml-cli/pom.xml
+++ b/drools-drlonyaml-parent/drools-drlonyaml-cli/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-drlonyaml-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>drools-drlonyaml-cli</artifactId>
   <name>Drools :: DRL on YAML :: CLI</name>

--- a/drools-drlonyaml-parent/drools-drlonyaml-integration-tests/pom.xml
+++ b/drools-drlonyaml-parent/drools-drlonyaml-integration-tests/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-drlonyaml-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>drools-drlonyaml-integration-tests</artifactId>
   <name>Drools :: DRL on YAML :: Integration Tests</name>

--- a/drools-drlonyaml-parent/drools-drlonyaml-model/pom.xml
+++ b/drools-drlonyaml-parent/drools-drlonyaml-model/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-drlonyaml-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>drools-drlonyaml-model</artifactId>
   <name>Drools :: DRL on YAML :: model</name>

--- a/drools-drlonyaml-parent/drools-drlonyaml-schemagen/pom.xml
+++ b/drools-drlonyaml-parent/drools-drlonyaml-schemagen/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-drlonyaml-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>drools-drlonyaml-schemagen</artifactId>
   <name>Drools :: DRL on YAML :: schema generator</name>

--- a/drools-drlonyaml-parent/drools-drlonyaml-todrl/pom.xml
+++ b/drools-drlonyaml-parent/drools-drlonyaml-todrl/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-drlonyaml-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>drools-drlonyaml-todrl</artifactId>
   <name>Drools :: DRL on YAML :: to DRL emitter</name>

--- a/drools-drlonyaml-parent/pom.xml
+++ b/drools-drlonyaml-parent/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
   <groupId>org.drools</groupId>

--- a/drools-ecj/pom.xml
+++ b/drools-ecj/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>drools-build-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
         <relativePath>../build-parent/pom.xml</relativePath>
     </parent>
 

--- a/drools-engine-classic/pom.xml
+++ b/drools-engine-classic/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-engine/pom.xml
+++ b/drools-engine/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-examples-api/default-kiesession-from-file/pom.xml
+++ b/drools-examples-api/default-kiesession-from-file/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-api</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>default-kiesession-from-file</artifactId>

--- a/drools-examples-api/default-kiesession/pom.xml
+++ b/drools-examples-api/default-kiesession/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-api</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>default-kiesession</artifactId>

--- a/drools-examples-api/kie-module-from-multiple-files/pom.xml
+++ b/drools-examples-api/kie-module-from-multiple-files/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-api</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-module-from-multiple-files</artifactId>

--- a/drools-examples-api/kiebase-inclusion/pom.xml
+++ b/drools-examples-api/kiebase-inclusion/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-api</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kiebase-inclusion</artifactId>

--- a/drools-examples-api/kiecontainer-from-kierepo/pom.xml
+++ b/drools-examples-api/kiecontainer-from-kierepo/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-api</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kiecontainer-from-kierepo</artifactId>

--- a/drools-examples-api/kiefilesystem-example/pom.xml
+++ b/drools-examples-api/kiefilesystem-example/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-api</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kiefilesystem-example</artifactId>

--- a/drools-examples-api/kiemodulemodel-example/pom.xml
+++ b/drools-examples-api/kiemodulemodel-example/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-api</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kiemodulemodel-example</artifactId>

--- a/drools-examples-api/multiple-kbases/pom.xml
+++ b/drools-examples-api/multiple-kbases/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-api</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>multiple-kbases</artifactId>

--- a/drools-examples-api/named-kiesession-from-file/pom.xml
+++ b/drools-examples-api/named-kiesession-from-file/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-api</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <name>Drools :: API examples :: Named KieSession from File</name>

--- a/drools-examples-api/named-kiesession/pom.xml
+++ b/drools-examples-api/named-kiesession/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-api</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>named-kiesession</artifactId>

--- a/drools-examples-api/pom.xml
+++ b/drools-examples-api/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-examples-api/reactive-kiesession/pom.xml
+++ b/drools-examples-api/reactive-kiesession/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-api</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>reactive-kiesession</artifactId>

--- a/drools-examples/pom.xml
+++ b/drools-examples/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-fastutil/pom.xml
+++ b/drools-fastutil/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>drools-build-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
         <relativePath>../build-parent/pom.xml</relativePath>
     </parent>
 

--- a/drools-impact-analysis/drools-impact-analysis-graph/drools-impact-analysis-graph-common/pom.xml
+++ b/drools-impact-analysis/drools-impact-analysis-graph/drools-impact-analysis-graph-common/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>drools-impact-analysis-graph</artifactId>
     <groupId>org.drools</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-impact-analysis/drools-impact-analysis-graph/drools-impact-analysis-graph-graphviz/pom.xml
+++ b/drools-impact-analysis/drools-impact-analysis-graph/drools-impact-analysis-graph-graphviz/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>drools-impact-analysis-graph</artifactId>
     <groupId>org.drools</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-impact-analysis/drools-impact-analysis-graph/drools-impact-analysis-graph-json/pom.xml
+++ b/drools-impact-analysis/drools-impact-analysis-graph/drools-impact-analysis-graph-json/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>drools-impact-analysis-graph</artifactId>
     <groupId>org.drools</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-impact-analysis/drools-impact-analysis-graph/pom.xml
+++ b/drools-impact-analysis/drools-impact-analysis-graph/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>drools-impact-analysis</artifactId>
     <groupId>org.drools</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-impact-analysis/drools-impact-analysis-itests/pom.xml
+++ b/drools-impact-analysis/drools-impact-analysis-itests/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>drools-impact-analysis</artifactId>
     <groupId>org.drools</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-impact-analysis/drools-impact-analysis-model/pom.xml
+++ b/drools-impact-analysis/drools-impact-analysis-model/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>drools-impact-analysis</artifactId>
     <groupId>org.drools</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-impact-analysis/drools-impact-analysis-parser/pom.xml
+++ b/drools-impact-analysis/drools-impact-analysis-parser/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>drools-impact-analysis</artifactId>
     <groupId>org.drools</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-impact-analysis/pom.xml
+++ b/drools-impact-analysis/pom.xml
@@ -42,7 +42,6 @@
     <module>drools-impact-analysis-model</module>
     <module>drools-impact-analysis-parser</module>
     <module>drools-impact-analysis-graph</module>
-    <module>drools-impact-analysis-itests</module>
   </modules>
 
 </project>

--- a/drools-impact-analysis/pom.xml
+++ b/drools-impact-analysis/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-io/pom.xml
+++ b/drools-io/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>drools-build-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
         <relativePath>../build-parent/pom.xml</relativePath>
     </parent>
 

--- a/drools-kiesession/pom.xml
+++ b/drools-kiesession/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-legacy-test-util/pom.xml
+++ b/drools-legacy-test-util/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>drools-build-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
         <relativePath>../build-parent/pom.xml</relativePath>
     </parent>
 

--- a/drools-metric/pom.xml
+++ b/drools-metric/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-model/drools-canonical-model/pom.xml
+++ b/drools-model/drools-canonical-model/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-model</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <name>Drools :: Canonical Model</name>

--- a/drools-model/drools-codegen-common/pom.xml
+++ b/drools-model/drools-codegen-common/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.drools</groupId>
         <artifactId>drools-model</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>drools-codegen-common</artifactId>

--- a/drools-model/drools-model-codegen/pom.xml
+++ b/drools-model/drools-model-codegen/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.drools</groupId>
         <artifactId>drools-model</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <groupId>org.drools</groupId>

--- a/drools-model/drools-model-compiler/pom.xml
+++ b/drools-model/drools-model-compiler/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-model</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <name>Drools :: Model :: Compiler</name>

--- a/drools-model/drools-model-prototype/pom.xml
+++ b/drools-model/drools-model-prototype/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-model</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <name>Drools :: Canonical Model :: Prototype</name>

--- a/drools-model/drools-mvel-compiler/pom.xml
+++ b/drools-model/drools-mvel-compiler/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-model</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <name>Drools :: MVEL Compiler</name>

--- a/drools-model/drools-mvel-parser/pom.xml
+++ b/drools-model/drools-mvel-parser/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-model</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <name>Drools :: MVEL Parser</name>

--- a/drools-model/pom.xml
+++ b/drools-model/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-mvel/pom.xml
+++ b/drools-mvel/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>drools-build-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
         <relativePath>../build-parent/pom.xml</relativePath>
     </parent>
 

--- a/drools-persistence/drools-persistence-api/pom.xml
+++ b/drools-persistence/drools-persistence-api/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-persistence</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-persistence-api</artifactId>

--- a/drools-persistence/drools-persistence-jpa/pom.xml
+++ b/drools-persistence/drools-persistence-jpa/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-persistence</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-persistence-jpa</artifactId>

--- a/drools-persistence/pom.xml
+++ b/drools-persistence/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-quarkus-extension/drools-quarkus-deployment/pom.xml
+++ b/drools-quarkus-extension/drools-quarkus-deployment/pom.xml
@@ -26,7 +26,7 @@
     <parent>
       <groupId>org.drools</groupId>
       <artifactId>drools-quarkus-extension</artifactId>
-      <version>999-SNAPSHOT</version>
+      <version>111-SNAPSHOT</version>
     </parent>
 
   <name>Drools :: Quarkus Extension :: Deployment</name>

--- a/drools-quarkus-extension/drools-quarkus-examples/drools-quarkus-examples-multiunit/pom.xml
+++ b/drools-quarkus-extension/drools-quarkus-examples/drools-quarkus-examples-multiunit/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-quarkus-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <name>Drools :: Quarkus Extension :: Examples :: Multiunit</name>

--- a/drools-quarkus-extension/drools-quarkus-examples/drools-quarkus-examples-reactive/pom.xml
+++ b/drools-quarkus-extension/drools-quarkus-examples/drools-quarkus-examples-reactive/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-quarkus-examples</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <name>Drools :: Quarkus Extension :: Examples :: Reactive</name>

--- a/drools-quarkus-extension/drools-quarkus-examples/pom.xml
+++ b/drools-quarkus-extension/drools-quarkus-examples/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.drools</groupId>
         <artifactId>drools-quarkus-extension</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <name>Drools :: Quarkus Extension :: Examples</name>

--- a/drools-quarkus-extension/drools-quarkus-integration-test-hotreload/pom.xml
+++ b/drools-quarkus-extension/drools-quarkus-integration-test-hotreload/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-quarkus-extension</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <name>Drools :: Quarkus Extension :: Integration Test :: Hotreload</name>

--- a/drools-quarkus-extension/drools-quarkus-integration-test-kmodule/pom.xml
+++ b/drools-quarkus-extension/drools-quarkus-integration-test-kmodule/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-quarkus-extension</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <name>Drools :: Quarkus Extension :: Integration Test :: kmodule xml</name>

--- a/drools-quarkus-extension/drools-quarkus-integration-test-multimodule/drools-quarkus-integration-test-multimodule-dep/pom.xml
+++ b/drools-quarkus-extension/drools-quarkus-integration-test-multimodule/drools-quarkus-integration-test-multimodule-dep/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-quarkus-integration-test-multimodule</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <name>Drools :: Quarkus Extension :: Integration Test :: Multi Module :: Asset Dependency Jar</name>

--- a/drools-quarkus-extension/drools-quarkus-integration-test-multimodule/drools-quarkus-integration-test-multimodule-main/pom.xml
+++ b/drools-quarkus-extension/drools-quarkus-integration-test-multimodule/drools-quarkus-integration-test-multimodule-main/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-quarkus-integration-test-multimodule</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <name>Drools :: Quarkus Extension :: Integration Test :: Multi Module :: Main</name>

--- a/drools-quarkus-extension/drools-quarkus-integration-test-multimodule/pom.xml
+++ b/drools-quarkus-extension/drools-quarkus-integration-test-multimodule/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-quarkus-extension</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <name>Drools :: Quarkus Extension :: Integration Test :: Multi Module</name>

--- a/drools-quarkus-extension/drools-quarkus-integration-test/pom.xml
+++ b/drools-quarkus-extension/drools-quarkus-integration-test/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-quarkus-extension</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <name>Drools :: Quarkus Extension :: Integration Test</name>

--- a/drools-quarkus-extension/drools-quarkus-quickstart-test/pom.xml
+++ b/drools-quarkus-extension/drools-quarkus-quickstart-test/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-quarkus-extension</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <name>Drools :: Quarkus Extension :: Quickstart Integration Test</name>

--- a/drools-quarkus-extension/drools-quarkus-ruleunit-integration-test-norest/pom.xml
+++ b/drools-quarkus-extension/drools-quarkus-ruleunit-integration-test-norest/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-quarkus-extension</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <name>Drools :: Quarkus Extension :: Integration Test :: Ruleunits :: No REST</name>

--- a/drools-quarkus-extension/drools-quarkus-ruleunit-integration-test/pom.xml
+++ b/drools-quarkus-extension/drools-quarkus-ruleunit-integration-test/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-quarkus-extension</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <name>Drools :: Quarkus Extension :: Integration Test :: Ruleunits</name>

--- a/drools-quarkus-extension/drools-quarkus-ruleunits-deployment/pom.xml
+++ b/drools-quarkus-extension/drools-quarkus-ruleunits-deployment/pom.xml
@@ -26,7 +26,7 @@
     <parent>
       <groupId>org.drools</groupId>
       <artifactId>drools-quarkus-extension</artifactId>
-      <version>999-SNAPSHOT</version>
+      <version>111-SNAPSHOT</version>
     </parent>
 
   <name>Drools :: Quarkus Extension :: Deployment :: Ruleunits</name>

--- a/drools-quarkus-extension/drools-quarkus-ruleunits/pom.xml
+++ b/drools-quarkus-extension/drools-quarkus-ruleunits/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.drools</groupId>
         <artifactId>drools-quarkus-extension</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>drools-quarkus-ruleunits</artifactId>

--- a/drools-quarkus-extension/drools-quarkus-util-deployment/pom.xml
+++ b/drools-quarkus-extension/drools-quarkus-util-deployment/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.drools</groupId>
         <artifactId>drools-quarkus-extension</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <name>Drools :: Quarkus Extension :: Util :: Deployment</name>

--- a/drools-quarkus-extension/drools-quarkus/pom.xml
+++ b/drools-quarkus-extension/drools-quarkus/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.drools</groupId>
         <artifactId>drools-quarkus-extension</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>drools-quarkus</artifactId>

--- a/drools-quarkus-extension/pom.xml
+++ b/drools-quarkus-extension/pom.xml
@@ -37,18 +37,9 @@
 
   <modules>
     <module>drools-quarkus-util-deployment</module>
-    <module>drools-quarkus</module>
-    <module>drools-quarkus-deployment</module>
     <module>drools-quarkus-ruleunits</module>
     <module>drools-quarkus-ruleunits-deployment</module>
-    <module>drools-quarkus-integration-test</module>
-    <module>drools-quarkus-integration-test-kmodule</module>
-    <module>drools-quarkus-integration-test-hotreload</module>
-    <module>drools-quarkus-integration-test-multimodule</module>
-    <module>drools-quarkus-ruleunit-integration-test</module>
     <module>drools-quarkus-ruleunit-integration-test-norest</module>
-    <module>drools-quarkus-quickstart-test</module>
-    <module>drools-quarkus-examples</module>
   </modules>
 
   <dependencyManagement>

--- a/drools-quarkus-extension/pom.xml
+++ b/drools-quarkus-extension/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-reliability/drools-reliability-core/pom.xml
+++ b/drools-reliability/drools-reliability-core/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-reliability</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-reliability/drools-reliability-h2mvstore/pom.xml
+++ b/drools-reliability/drools-reliability-h2mvstore/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-reliability</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-reliability/drools-reliability-infinispan/pom.xml
+++ b/drools-reliability/drools-reliability-infinispan/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-reliability</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-reliability/drools-reliability-tests/pom.xml
+++ b/drools-reliability/drools-reliability-tests/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-reliability</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-reliability/pom.xml
+++ b/drools-reliability/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/drools-retediagram/pom.xml
+++ b/drools-retediagram/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-ruleunits/drools-ruleunits-api/pom.xml
+++ b/drools-ruleunits/drools-ruleunits-api/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.drools</groupId>
         <artifactId>drools-ruleunits</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <groupId>org.drools</groupId>

--- a/drools-ruleunits/drools-ruleunits-dsl/pom.xml
+++ b/drools-ruleunits/drools-ruleunits-dsl/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.drools</groupId>
         <artifactId>drools-ruleunits</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <groupId>org.drools</groupId>

--- a/drools-ruleunits/drools-ruleunits-engine/pom.xml
+++ b/drools-ruleunits/drools-ruleunits-engine/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-ruleunits</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-ruleunits-engine</artifactId>

--- a/drools-ruleunits/drools-ruleunits-impl/pom.xml
+++ b/drools-ruleunits/drools-ruleunits-impl/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.drools</groupId>
         <artifactId>drools-ruleunits</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <groupId>org.drools</groupId>

--- a/drools-ruleunits/pom.xml
+++ b/drools-ruleunits/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-scenario-simulation/drools-scenario-simulation-api/pom.xml
+++ b/drools-scenario-simulation/drools-scenario-simulation-api/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>drools-scenario-simulation</artifactId>
     <groupId>org.drools</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-scenario-simulation/drools-scenario-simulation-backend/pom.xml
+++ b/drools-scenario-simulation/drools-scenario-simulation-backend/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>drools-scenario-simulation</artifactId>
     <groupId>org.drools</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-scenario-simulation/drools-scenario-simulation-integrationtest/pom.xml
+++ b/drools-scenario-simulation/drools-scenario-simulation-integrationtest/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>drools-scenario-simulation</artifactId>
     <groupId>org.drools</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-scenario-simulation/pom.xml
+++ b/drools-scenario-simulation/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-serialization-protobuf/pom.xml
+++ b/drools-serialization-protobuf/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>drools-build-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
         <relativePath>../build-parent/pom.xml</relativePath>
     </parent>
 

--- a/drools-templates/pom.xml
+++ b/drools-templates/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-test-coverage/drools-test-coverage-jars/drools-test-coverage-jars-with-invoker/pom.xml
+++ b/drools-test-coverage/drools-test-coverage-jars/drools-test-coverage-jars-with-invoker/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>drools-test-coverage-jars</artifactId>
     <groupId>org.drools.testcoverage</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-test-coverage/drools-test-coverage-jars/drools-test-coverage-jars-with-invoker/src/it/kie-project-simple/pom.xml
+++ b/drools-test-coverage/drools-test-coverage-jars/drools-test-coverage-jars-with-invoker/src/it/kie-project-simple/pom.xml
@@ -25,7 +25,7 @@
 
   <groupId>org.drools.testcoverage</groupId>
   <artifactId>kie-project-simple</artifactId>
-  <version>1.0.0</version>
+  <version>111-SNAPSHOT</version>
   <packaging>kjar</packaging>
 
   <name>kie-project-simple</name>

--- a/drools-test-coverage/drools-test-coverage-jars/drools-test-coverage-jars-with-invoker/src/it/kjar-module-after/pom.xml
+++ b/drools-test-coverage/drools-test-coverage-jars/drools-test-coverage-jars-with-invoker/src/it/kjar-module-after/pom.xml
@@ -25,7 +25,7 @@
 
   <groupId>org.kie.test</groupId>
   <artifactId>test-module</artifactId>
-  <version>1.2.0-SNAPSHOT</version>
+  <version>111-SNAPSHOT</version>
   <packaging>kjar</packaging>
 
   <properties>

--- a/drools-test-coverage/drools-test-coverage-jars/drools-test-coverage-jars-with-invoker/src/it/kjar-module-before/pom.xml
+++ b/drools-test-coverage/drools-test-coverage-jars/drools-test-coverage-jars-with-invoker/src/it/kjar-module-before/pom.xml
@@ -25,7 +25,7 @@
 
   <groupId>org.kie.test</groupId>
   <artifactId>test-module</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
+  <version>111-SNAPSHOT</version>
   <packaging>kjar</packaging>
 
   <properties>

--- a/drools-test-coverage/drools-test-coverage-jars/drools-test-coverage-jars-with-invoker/src/it/only-jar-pojo-not-kjar-no-kmodule/pom.xml
+++ b/drools-test-coverage/drools-test-coverage-jars/drools-test-coverage-jars-with-invoker/src/it/only-jar-pojo-not-kjar-no-kmodule/pom.xml
@@ -25,7 +25,7 @@
 
   <groupId>org.drools.testcoverage</groupId>
   <artifactId>only-jar-pojo-not-kjar-no-kmodule</artifactId>
-  <version>1.0.0</version>
+  <version>111-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/drools-test-coverage/drools-test-coverage-jars/pom.xml
+++ b/drools-test-coverage/drools-test-coverage-jars/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <artifactId>drools-test-coverage-parent</artifactId>
     <groupId>org.drools.testcoverage</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-test-coverage/drools-test-coverage-jars/setter-overload/pom.xml
+++ b/drools-test-coverage/drools-test-coverage-jars/setter-overload/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <artifactId>drools-test-coverage-jars</artifactId>
     <groupId>org.drools.testcoverage</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-test-coverage/drools-test-coverage-jars/surf/pom.xml
+++ b/drools-test-coverage/drools-test-coverage-jars/surf/pom.xml
@@ -25,7 +25,7 @@
 
   <groupId>org.drools.testcoverage</groupId>
   <artifactId>surf</artifactId>
-  <version>1.0.0</version>
+  <version>111-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Drools :: Test Coverage :: Jar with simple pojo</name>

--- a/drools-test-coverage/drools-test-coverage-jars/testEnum/pom.xml
+++ b/drools-test-coverage/drools-test-coverage-jars/testEnum/pom.xml
@@ -25,7 +25,7 @@
 
   <groupId>org.drools.testcoverage</groupId>
   <artifactId>testEnum</artifactId>
-  <version>1.0.0</version>
+  <version>111-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Drools :: Test Coverage :: Jar with enum</name>

--- a/drools-test-coverage/pom.xml
+++ b/drools-test-coverage/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-test-coverage/standalone/kie-ci-with-domain/pom.xml
+++ b/drools-test-coverage/standalone/kie-ci-with-domain/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.drools.testcoverage</groupId>
     <artifactId>drools-standalone-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-kie-ci-with-domain-parent</artifactId>

--- a/drools-test-coverage/standalone/kie-ci-with-domain/test-domain/pom.xml
+++ b/drools-test-coverage/standalone/kie-ci-with-domain/test-domain/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.drools.testcoverage</groupId>
     <artifactId>drools-kie-ci-with-domain-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-kie-ci-with-domain-test-domain</artifactId>

--- a/drools-test-coverage/standalone/kie-ci-with-domain/test-kjar/pom.xml
+++ b/drools-test-coverage/standalone/kie-ci-with-domain/test-kjar/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.drools.testcoverage</groupId>
     <artifactId>drools-kie-ci-with-domain-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-kie-ci-with-domain-test-kjar</artifactId>

--- a/drools-test-coverage/standalone/kie-ci-with-domain/tests/pom.xml
+++ b/drools-test-coverage/standalone/kie-ci-with-domain/tests/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.drools.testcoverage</groupId>
     <artifactId>drools-kie-ci-with-domain-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-kie-ci-with-domain-tests</artifactId>

--- a/drools-test-coverage/standalone/kie-ci-without-domain/pom.xml
+++ b/drools-test-coverage/standalone/kie-ci-without-domain/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.drools.testcoverage</groupId>
     <artifactId>drools-standalone-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-kie-ci-without-domain-parent</artifactId>

--- a/drools-test-coverage/standalone/kie-ci-without-domain/test-domain/pom.xml
+++ b/drools-test-coverage/standalone/kie-ci-without-domain/test-domain/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.drools.testcoverage</groupId>
     <artifactId>drools-kie-ci-without-domain-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-kie-ci-without-domain-test-domain</artifactId>

--- a/drools-test-coverage/standalone/kie-ci-without-domain/test-kjar/pom.xml
+++ b/drools-test-coverage/standalone/kie-ci-without-domain/test-kjar/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.drools.testcoverage</groupId>
     <artifactId>drools-kie-ci-without-domain-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-kie-ci-without-domain-test-kjar</artifactId>

--- a/drools-test-coverage/standalone/kie-ci-without-domain/tests/pom.xml
+++ b/drools-test-coverage/standalone/kie-ci-without-domain/tests/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.drools.testcoverage</groupId>
     <artifactId>drools-kie-ci-without-domain-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-kie-ci-without-domain-tests</artifactId>

--- a/drools-test-coverage/standalone/pom.xml
+++ b/drools-test-coverage/standalone/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.drools.testcoverage</groupId>
     <artifactId>drools-test-coverage-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-standalone-parent</artifactId>

--- a/drools-test-coverage/test-compiler-integration/pom.xml
+++ b/drools-test-coverage/test-compiler-integration/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <artifactId>drools-test-coverage-parent</artifactId>
     <groupId>org.drools.testcoverage</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-test-coverage/test-integration-nomvel/pom.xml
+++ b/drools-test-coverage/test-integration-nomvel/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <artifactId>drools-test-coverage-parent</artifactId>
         <groupId>org.drools.testcoverage</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/drools-test-coverage/test-integration-notms/pom.xml
+++ b/drools-test-coverage/test-integration-notms/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <artifactId>drools-test-coverage-parent</artifactId>
         <groupId>org.drools.testcoverage</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/drools-test-coverage/test-integration-noxml/pom.xml
+++ b/drools-test-coverage/test-integration-noxml/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <artifactId>drools-test-coverage-parent</artifactId>
         <groupId>org.drools.testcoverage</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/drools-test-coverage/test-integration-ruleunits/pom.xml
+++ b/drools-test-coverage/test-integration-ruleunits/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <artifactId>drools-test-coverage-parent</artifactId>
     <groupId>org.drools.testcoverage</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-test-coverage/test-integration-ruleunits/test-integration-ruleunits-jar/pom.xml
+++ b/drools-test-coverage/test-integration-ruleunits/test-integration-ruleunits-jar/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <artifactId>test-integration-ruleunits</artifactId>
     <groupId>org.drools.testcoverage</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-test-coverage/test-integration-ruleunits/test-integration-ruleunits-tests/pom.xml
+++ b/drools-test-coverage/test-integration-ruleunits/test-integration-ruleunits-tests/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <artifactId>test-integration-ruleunits</artifactId>
     <groupId>org.drools.testcoverage</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-test-coverage/test-suite/pom.xml
+++ b/drools-test-coverage/test-suite/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.drools.testcoverage</groupId>
     <artifactId>drools-test-coverage-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-test-suite</artifactId>

--- a/drools-tms/pom.xml
+++ b/drools-tms/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-traits/pom.xml
+++ b/drools-traits/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-util/pom.xml
+++ b/drools-util/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>drools-build-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
         <relativePath>../build-parent/pom.xml</relativePath>
     </parent>
 

--- a/drools-verifier/drools-verifier-api/pom.xml
+++ b/drools-verifier/drools-verifier-api/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.drools</groupId>
         <artifactId>drools-verifier</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/drools-verifier/drools-verifier-core/pom.xml
+++ b/drools-verifier/drools-verifier-core/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <artifactId>drools-verifier</artifactId>
         <groupId>org.drools</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/drools-verifier/drools-verifier-drl/pom.xml
+++ b/drools-verifier/drools-verifier-drl/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-verifier</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-verifier-drl</artifactId>

--- a/drools-verifier/drools-verifier-test-jar/pom.xml
+++ b/drools-verifier/drools-verifier-test-jar/pom.xml
@@ -25,7 +25,7 @@
 
   <groupId>org.drools</groupId>
   <artifactId>drools-verifier-test-jar</artifactId>
-  <version>1.0.0</version>
+  <version>111-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Drools :: Verifier :: jar for test</name>

--- a/drools-verifier/pom.xml
+++ b/drools-verifier/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-wiring/drools-wiring-api/pom.xml
+++ b/drools-wiring/drools-wiring-api/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.drools</groupId>
         <artifactId>drools-wiring</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <groupId>org.drools</groupId>

--- a/drools-wiring/drools-wiring-dynamic/pom.xml
+++ b/drools-wiring/drools-wiring-dynamic/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-wiring</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <groupId>org.drools</groupId>

--- a/drools-wiring/drools-wiring-static/pom.xml
+++ b/drools-wiring/drools-wiring-static/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-wiring</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <groupId>org.drools</groupId>

--- a/drools-wiring/pom.xml
+++ b/drools-wiring/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools-xml-support/pom.xml
+++ b/drools-xml-support/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/efesto/efesto-common-utils/pom.xml
+++ b/efesto/efesto-common-utils/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>efesto</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>efesto-common-utils</artifactId>

--- a/efesto/efesto-core/efesto-common-api/pom.xml
+++ b/efesto/efesto-core/efesto-common-api/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>efesto-core</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>efesto-common-api</artifactId>

--- a/efesto/efesto-core/efesto-common-core/pom.xml
+++ b/efesto/efesto-core/efesto-common-core/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>efesto-core</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>efesto-common-core</artifactId>

--- a/efesto/efesto-core/efesto-compilation-manager/efesto-compilation-manager-api/pom.xml
+++ b/efesto/efesto-core/efesto-compilation-manager/efesto-compilation-manager-api/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>efesto-compilation-manager</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>efesto-compilation-manager-api</artifactId>

--- a/efesto/efesto-core/efesto-compilation-manager/efesto-compilation-manager-core/pom.xml
+++ b/efesto/efesto-core/efesto-compilation-manager/efesto-compilation-manager-core/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>efesto-compilation-manager</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>efesto-compilation-manager-core</artifactId>

--- a/efesto/efesto-core/efesto-compilation-manager/pom.xml
+++ b/efesto/efesto-core/efesto-compilation-manager/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>efesto-core</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <packaging>pom</packaging>
 

--- a/efesto/efesto-core/efesto-runtime-manager/efesto-runtime-manager-api/pom.xml
+++ b/efesto/efesto-core/efesto-runtime-manager/efesto-runtime-manager-api/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>efesto-runtime-manager</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
  <artifactId>efesto-runtime-manager-api</artifactId>

--- a/efesto/efesto-core/efesto-runtime-manager/efesto-runtime-manager-core/pom.xml
+++ b/efesto/efesto-core/efesto-runtime-manager/efesto-runtime-manager-core/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>efesto-runtime-manager</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>efesto-runtime-manager-core</artifactId>

--- a/efesto/efesto-core/efesto-runtime-manager/pom.xml
+++ b/efesto/efesto-core/efesto-runtime-manager/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>efesto-core</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <packaging>pom</packaging>
 

--- a/efesto/efesto-core/pom.xml
+++ b/efesto/efesto-core/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>efesto</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <packaging>pom</packaging>
 

--- a/efesto/efesto-dependencies/pom.xml
+++ b/efesto/efesto-dependencies/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>efesto</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/efesto/pom.xml
+++ b/efesto/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/kie-api/pom.xml
+++ b/kie-api/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/kie-archetypes/kie-drools-dmn-archetype/pom.xml
+++ b/kie-archetypes/kie-drools-dmn-archetype/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-archetypes</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-drools-dmn-archetype</artifactId>

--- a/kie-archetypes/kie-drools-dmn-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/kie-archetypes/kie-drools-dmn-archetype/src/main/resources/archetype-resources/pom.xml
@@ -27,7 +27,7 @@
 
   <groupId>${dollar}{groupId}</groupId>
   <artifactId>${dollar}{artifactId}</artifactId>
-  <version>${dollar}{version}</version>
+  <version>111-SNAPSHOT</version>
   <packaging>kjar</packaging>
 
   <name>${dollar}{artifactId}</name>

--- a/kie-archetypes/kie-drools-dmn-archetype/src/test/resources/projects/integrationtestDefaults/reference/pom.xml
+++ b/kie-archetypes/kie-drools-dmn-archetype/src/test/resources/projects/integrationtestDefaults/reference/pom.xml
@@ -24,7 +24,7 @@
 
   <groupId>archetype.it</groupId>
   <artifactId>basic</artifactId>
-  <version>0.1-SNAPSHOT</version>
+  <version>111-SNAPSHOT</version>
   <packaging>kjar</packaging>
 
   <name>basic</name>

--- a/kie-archetypes/kie-drools-exec-model-archetype/pom.xml
+++ b/kie-archetypes/kie-drools-exec-model-archetype/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-archetypes</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-drools-exec-model-archetype</artifactId>

--- a/kie-archetypes/kie-drools-exec-model-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/kie-archetypes/kie-drools-exec-model-archetype/src/main/resources/archetype-resources/pom.xml
@@ -27,7 +27,7 @@
 
   <groupId>${dollar}{groupId}</groupId>
   <artifactId>${dollar}{artifactId}</artifactId>
-  <version>${dollar}{version}</version>
+  <version>111-SNAPSHOT</version>
   <packaging>kjar</packaging>
 
   <name>${dollar}{artifactId}</name>

--- a/kie-archetypes/kie-drools-exec-model-archetype/src/test/resources/projects/integrationtestDefaults/reference/pom.xml
+++ b/kie-archetypes/kie-drools-exec-model-archetype/src/test/resources/projects/integrationtestDefaults/reference/pom.xml
@@ -24,7 +24,7 @@
 
   <groupId>archetype.it</groupId>
   <artifactId>basic</artifactId>
-  <version>0.1-SNAPSHOT</version>
+  <version>111-SNAPSHOT</version>
   <packaging>kjar</packaging>
 
   <name>basic</name>

--- a/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/pom.xml
+++ b/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-archetypes</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-drools-exec-model-ruleunit-archetype</artifactId>

--- a/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/main/resources/archetype-resources/pom.xml
@@ -27,7 +27,7 @@
 
   <groupId>${dollar}{groupId}</groupId>
   <artifactId>${dollar}{artifactId}</artifactId>
-  <version>${dollar}{version}</version>
+  <version>111-SNAPSHOT</version>
   <packaging>kjar</packaging>
 
   <name>${dollar}{artifactId}</name>

--- a/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/test/resources/projects/integrationtestDefaults/reference/pom.xml
+++ b/kie-archetypes/kie-drools-exec-model-ruleunit-archetype/src/test/resources/projects/integrationtestDefaults/reference/pom.xml
@@ -24,7 +24,7 @@
 
   <groupId>archetype.it</groupId>
   <artifactId>basic</artifactId>
-  <version>0.1-SNAPSHOT</version>
+  <version>111-SNAPSHOT</version>
   <packaging>kjar</packaging>
 
   <name>basic</name>

--- a/kie-archetypes/kie-drools-yaml-archetype/pom.xml
+++ b/kie-archetypes/kie-drools-yaml-archetype/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-archetypes</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-drools-yaml-archetype</artifactId>

--- a/kie-archetypes/kie-drools-yaml-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/kie-archetypes/kie-drools-yaml-archetype/src/main/resources/archetype-resources/pom.xml
@@ -27,7 +27,7 @@
 
   <groupId>${dollar}{groupId}</groupId>
   <artifactId>${dollar}{artifactId}</artifactId>
-  <version>${dollar}{version}</version>
+  <version>111-SNAPSHOT</version>
   <packaging>kjar</packaging>
 
   <name>${dollar}{artifactId}</name>

--- a/kie-archetypes/kie-drools-yaml-archetype/src/test/resources/projects/integrationtestDefaults/reference/pom.xml
+++ b/kie-archetypes/kie-drools-yaml-archetype/src/test/resources/projects/integrationtestDefaults/reference/pom.xml
@@ -24,7 +24,7 @@
 
   <groupId>archetype.it</groupId>
   <artifactId>basic</artifactId>
-  <version>0.1-SNAPSHOT</version>
+  <version>111-SNAPSHOT</version>
   <packaging>kjar</packaging>
 
   <name>basic</name>

--- a/kie-archetypes/pom.xml
+++ b/kie-archetypes/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/kie-ci/pom.xml
+++ b/kie-ci/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/kie-dmn/kie-dmn-api/pom.xml
+++ b/kie-dmn/kie-dmn-api/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-dmn</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-dmn-api</artifactId>

--- a/kie-dmn/kie-dmn-backend/pom.xml
+++ b/kie-dmn/kie-dmn-backend/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-dmn</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-dmn-backend</artifactId>

--- a/kie-dmn/kie-dmn-core-jsr223-jq/pom.xml
+++ b/kie-dmn/kie-dmn-core-jsr223-jq/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>kie-dmn</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <artifactId>kie-dmn-core-jsr223-jq</artifactId>
     <name>KIE :: Decision Model Notation :: JSR-223 JQ ScriptEngine</name>

--- a/kie-dmn/kie-dmn-core-jsr223/pom.xml
+++ b/kie-dmn/kie-dmn-core-jsr223/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-dmn</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-dmn-core-jsr223</artifactId>
   <name>KIE :: Decision Model Notation :: Core JSR-223</name>

--- a/kie-dmn/kie-dmn-core/pom.xml
+++ b/kie-dmn/kie-dmn-core/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <artifactId>kie-dmn</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-dmn-core</artifactId>

--- a/kie-dmn/kie-dmn-efesto-api/pom.xml
+++ b/kie-dmn/kie-dmn-efesto-api/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-dmn</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-dmn-efesto-api</artifactId>

--- a/kie-dmn/kie-dmn-efesto-compilation/pom.xml
+++ b/kie-dmn/kie-dmn-efesto-compilation/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>kie-dmn</artifactId>
-      <version>999-SNAPSHOT</version>
+      <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>kie-dmn-efesto-compilation</artifactId>

--- a/kie-dmn/kie-dmn-efesto-runtime/pom.xml
+++ b/kie-dmn/kie-dmn-efesto-runtime/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>kie-dmn</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>kie-dmn-efesto-runtime</artifactId>

--- a/kie-dmn/kie-dmn-feel/pom.xml
+++ b/kie-dmn/kie-dmn-feel/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-dmn</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-dmn-feel</artifactId>

--- a/kie-dmn/kie-dmn-legacy-tests/pom.xml
+++ b/kie-dmn/kie-dmn-legacy-tests/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-dmn</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-dmn-legacy-tests</artifactId>
   

--- a/kie-dmn/kie-dmn-model/pom.xml
+++ b/kie-dmn/kie-dmn-model/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <artifactId>kie-dmn</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-dmn-model</artifactId>

--- a/kie-dmn/kie-dmn-openapi/pom.xml
+++ b/kie-dmn/kie-dmn-openapi/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-dmn</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-dmn-openapi</artifactId>
   

--- a/kie-dmn/kie-dmn-pmml-tests-parent/kie-dmn-pmml-tests-trusty/pom.xml
+++ b/kie-dmn/kie-dmn-pmml-tests-parent/kie-dmn-pmml-tests-trusty/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kie-dmn-pmml-tests-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-dmn/kie-dmn-pmml-tests-parent/kie-dmn-pmml-tests/pom.xml
+++ b/kie-dmn/kie-dmn-pmml-tests-parent/kie-dmn-pmml-tests/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kie-dmn-pmml-tests-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-dmn/kie-dmn-pmml-tests-parent/pom.xml
+++ b/kie-dmn/kie-dmn-pmml-tests-parent/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kie-dmn</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>

--- a/kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn-cli/pom.xml
+++ b/kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn-cli/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-dmn-ruleset2dmn-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-dmn-ruleset2dmn-cli</artifactId>
   

--- a/kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn/pom.xml
+++ b/kie-dmn/kie-dmn-ruleset2dmn-parent/kie-dmn-ruleset2dmn/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-dmn-ruleset2dmn-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-dmn-ruleset2dmn</artifactId>
 

--- a/kie-dmn/kie-dmn-ruleset2dmn-parent/pom.xml
+++ b/kie-dmn/kie-dmn-ruleset2dmn-parent/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-dmn</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-dmn-ruleset2dmn-parent</artifactId>
   <packaging>pom</packaging>

--- a/kie-dmn/kie-dmn-signavio/pom.xml
+++ b/kie-dmn/kie-dmn-signavio/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-dmn</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-dmn-signavio</artifactId>
   

--- a/kie-dmn/kie-dmn-tck/pom.xml
+++ b/kie-dmn/kie-dmn-tck/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <artifactId>kie-dmn</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>

--- a/kie-dmn/kie-dmn-test-resources/pom.xml
+++ b/kie-dmn/kie-dmn-test-resources/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-dmn</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-dmn-test-resources</artifactId>

--- a/kie-dmn/kie-dmn-trisotech/pom.xml
+++ b/kie-dmn/kie-dmn-trisotech/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-dmn</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-dmn-trisotech</artifactId>
 

--- a/kie-dmn/kie-dmn-validation-bootstrap/pom.xml
+++ b/kie-dmn/kie-dmn-validation-bootstrap/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-dmn</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-dmn-validation-bootstrap</artifactId>
 

--- a/kie-dmn/kie-dmn-validation/pom.xml
+++ b/kie-dmn/kie-dmn-validation/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-dmn</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-dmn-validation</artifactId>
     <packaging>jar</packaging>

--- a/kie-dmn/kie-dmn-xls2dmn-cli/pom.xml
+++ b/kie-dmn/kie-dmn-xls2dmn-cli/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-dmn</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-dmn-xls2dmn-cli</artifactId>
   <packaging>jar</packaging>

--- a/kie-dmn/kie-dmn-xsd-resources/pom.xml
+++ b/kie-dmn/kie-dmn-xsd-resources/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-dmn</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-dmn-xsd-resources</artifactId>

--- a/kie-dmn/pom.xml
+++ b/kie-dmn/pom.xml
@@ -49,16 +49,6 @@
     <module>kie-dmn-efesto-runtime</module>
     <module>kie-dmn-validation-bootstrap</module>
     <module>kie-dmn-validation</module>
-    <module>kie-dmn-openapi</module>
-    <module>kie-dmn-tck</module>
-    <module>kie-dmn-legacy-tests</module>
-    <module>kie-dmn-trisotech</module>
-    <module>kie-dmn-signavio</module>
-    <module>kie-dmn-pmml-tests-parent</module>
-    <module>kie-dmn-xls2dmn-cli</module>
-    <module>kie-dmn-core-jsr223-jq</module>
-    <module>kie-dmn-core-jsr223</module>
-    <module>kie-dmn-ruleset2dmn-parent</module>
   </modules>
 
   <dependencyManagement>

--- a/kie-dmn/pom.xml
+++ b/kie-dmn/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/kie-drl/kie-drl-api/pom.xml
+++ b/kie-drl/kie-drl-api/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kie-drl</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-drl/kie-drl-compilation-common/pom.xml
+++ b/kie-drl/kie-drl-compilation-common/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kie-drl</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-drl/kie-drl-implementations/kie-drl-kiesession-local/kie-drl-kiesession-local-runtime/pom.xml
+++ b/kie-drl/kie-drl-implementations/kie-drl-kiesession-local/kie-drl-kiesession-local-runtime/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kie-drl-kiesession-local</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-drl/kie-drl-implementations/kie-drl-kiesession-local/pom.xml
+++ b/kie-drl/kie-drl-implementations/kie-drl-kiesession-local/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <artifactId>kie-drl-implementations</artifactId>
         <groupId>org.kie</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/kie-drl/kie-drl-implementations/kie-drl-map-input/kie-drl-map-input-runtime/pom.xml
+++ b/kie-drl/kie-drl-implementations/kie-drl-map-input/kie-drl-map-input-runtime/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <artifactId>kie-drl-map-input</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-drl-map-input-runtime</artifactId>

--- a/kie-drl/kie-drl-implementations/kie-drl-map-input/pom.xml
+++ b/kie-drl/kie-drl-implementations/kie-drl-map-input/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <artifactId>kie-drl-implementations</artifactId>
         <groupId>org.kie</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/kie-drl/kie-drl-implementations/pom.xml
+++ b/kie-drl/kie-drl-implementations/pom.xml
@@ -38,7 +38,6 @@
 
     <modules>
         <module>kie-drl-map-input</module>
-        <module>kie-drl-kiesession-local</module>
     </modules>
 
 </project>

--- a/kie-drl/kie-drl-implementations/pom.xml
+++ b/kie-drl/kie-drl-implementations/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <artifactId>kie-drl</artifactId>
         <groupId>org.kie</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <name>KIE :: DRL :: Implementations</name>

--- a/kie-drl/kie-drl-runtime-common/pom.xml
+++ b/kie-drl/kie-drl-runtime-common/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kie-drl</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-drl/kie-drl-tests-without-index-file/pom.xml
+++ b/kie-drl/kie-drl-tests-without-index-file/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kie-drl</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-drl/kie-drl-tests/pom.xml
+++ b/kie-drl/kie-drl-tests/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kie-drl</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-drl/pom.xml
+++ b/kie-drl/pom.xml
@@ -42,8 +42,6 @@
     <module>kie-drl-compilation-common</module>
     <module>kie-drl-implementations</module>
     <module>kie-drl-runtime-common</module>
-    <module>kie-drl-tests</module>
-    <module>kie-drl-tests-without-index-file</module>
   </modules>
 
   <dependencyManagement>

--- a/kie-drl/pom.xml
+++ b/kie-drl/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/kie-internal/pom.xml
+++ b/kie-internal/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/kie-maven-plugin/pom.xml
+++ b/kie-maven-plugin/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-10-default/pom.xml
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-10-default/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-maven-plugin-test-kjar-parent</artifactId>
-    <version>@org.kie.version@</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../kie-maven-plugin-test-kjar-setup/kie-maven-plugin-test-kjar-parent/pom.xml</relativePath>
   </parent>
 

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-10-yes-generate/pom.xml
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-10-yes-generate/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-maven-plugin-test-kjar-parent</artifactId>
-    <version>@org.kie.version@</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../kie-maven-plugin-test-kjar-setup/kie-maven-plugin-test-kjar-parent/pom.xml</relativePath>
   </parent>
 

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-11-default/pom.xml
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-11-default/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-maven-plugin-test-kjar-parent</artifactId>
-    <version>@org.kie.version@</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../kie-maven-plugin-test-kjar-setup/kie-maven-plugin-test-kjar-parent/pom.xml</relativePath>
   </parent>
 

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-11-yes-generate/pom.xml
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-11-yes-generate/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-maven-plugin-test-kjar-parent</artifactId>
-    <version>@org.kie.version@</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../kie-maven-plugin-test-kjar-setup/kie-maven-plugin-test-kjar-parent/pom.xml</relativePath>
   </parent>
 

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-12/pom.xml
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-12/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-maven-plugin-test-kjar-parent</artifactId>
-    <version>@org.kie.version@</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../kie-maven-plugin-test-kjar-setup/kie-maven-plugin-test-kjar-parent/pom.xml</relativePath>
   </parent>
 

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-13/pom.xml
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-13/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-maven-plugin-test-kjar-parent</artifactId>
-    <version>@org.kie.version@</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../kie-maven-plugin-test-kjar-setup/kie-maven-plugin-test-kjar-parent/pom.xml</relativePath>
   </parent>
 

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-14-ruleunits/pom.xml
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-14-ruleunits/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-maven-plugin-test-kjar-parent</artifactId>
-    <version>@org.kie.version@</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../kie-maven-plugin-test-kjar-setup/kie-maven-plugin-test-kjar-parent/pom.xml</relativePath>
   </parent>
 

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-15-yaml/pom.xml
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-15-yaml/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-maven-plugin-test-kjar-parent</artifactId>
-    <version>@org.kie.version@</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../kie-maven-plugin-test-kjar-setup/kie-maven-plugin-test-kjar-parent/pom.xml</relativePath>
   </parent>
 

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-16-java21/pom.xml
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-16-java21/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-maven-plugin-test-kjar-parent</artifactId>
-    <version>@org.kie.version@</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../kie-maven-plugin-test-kjar-setup/kie-maven-plugin-test-kjar-parent/pom.xml</relativePath>
   </parent>
 

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-2/pom.xml
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-2/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-maven-plugin-test-kjar-parent</artifactId>
-    <version>@org.kie.version@</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../kie-maven-plugin-test-kjar-setup/kie-maven-plugin-test-kjar-parent/pom.xml</relativePath>
   </parent>
 

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-3/pom.xml
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-3/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-maven-plugin-test-kjar-parent</artifactId>
-    <version>@org.kie.version@</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../kie-maven-plugin-test-kjar-setup/kie-maven-plugin-test-kjar-parent/pom.xml</relativePath>
   </parent>
 

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-7-exec-model/pom.xml
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-7-exec-model/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-maven-plugin-test-kjar-parent</artifactId>
-    <version>@org.kie.version@</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../kie-maven-plugin-test-kjar-setup/kie-maven-plugin-test-kjar-parent/pom.xml</relativePath>
   </parent>
 

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-7-no-exec-model/pom.xml
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-7-no-exec-model/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-maven-plugin-test-kjar-parent</artifactId>
-    <version>@org.kie.version@</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../kie-maven-plugin-test-kjar-setup/kie-maven-plugin-test-kjar-parent/pom.xml</relativePath>
   </parent>
 

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-8-exec-model/kie-maven-plugin-test-kjar-8-modA-exec-model/pom.xml
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-8-exec-model/kie-maven-plugin-test-kjar-8-modA-exec-model/pom.xml
@@ -31,7 +31,7 @@
   <parent>
     <artifactId>kie-maven-plugin-test-kjar-8-exec-model</artifactId>
     <groupId>org.kie</groupId>
-    <version>@org.kie.version@</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-8-exec-model/kie-maven-plugin-test-kjar-8-modB-exec-model/pom.xml
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-8-exec-model/kie-maven-plugin-test-kjar-8-modB-exec-model/pom.xml
@@ -31,7 +31,7 @@
   <parent>
     <artifactId>kie-maven-plugin-test-kjar-8-exec-model</artifactId>
     <groupId>org.kie</groupId>
-    <version>@org.kie.version@</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-8-exec-model/kie-maven-plugin-test-kjar-8-modC-exec-model/pom.xml
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-8-exec-model/kie-maven-plugin-test-kjar-8-modC-exec-model/pom.xml
@@ -31,7 +31,7 @@
   <parent>
     <artifactId>kie-maven-plugin-test-kjar-8-exec-model</artifactId>
     <groupId>org.kie</groupId>
-    <version>@org.kie.version@</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-8-exec-model/pom.xml
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-8-exec-model/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-maven-plugin-test-kjar-parent</artifactId>
-    <version>@org.kie.version@</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../kie-maven-plugin-test-kjar-setup/kie-maven-plugin-test-kjar-parent/pom.xml</relativePath>
   </parent>
 

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-8-no-exec-model/kie-maven-plugin-test-kjar-8-modA-no-exec-model/pom.xml
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-8-no-exec-model/kie-maven-plugin-test-kjar-8-modA-no-exec-model/pom.xml
@@ -31,7 +31,7 @@
   <parent>
     <artifactId>kie-maven-plugin-test-kjar-8-no-exec-model</artifactId>
     <groupId>org.kie</groupId>
-    <version>@org.kie.version@</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-8-no-exec-model/kie-maven-plugin-test-kjar-8-modB-no-exec-model/pom.xml
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-8-no-exec-model/kie-maven-plugin-test-kjar-8-modB-no-exec-model/pom.xml
@@ -31,7 +31,7 @@
   <parent>
     <artifactId>kie-maven-plugin-test-kjar-8-no-exec-model</artifactId>
     <groupId>org.kie</groupId>
-    <version>@org.kie.version@</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-8-no-exec-model/kie-maven-plugin-test-kjar-8-modC-no-exec-model/pom.xml
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-8-no-exec-model/kie-maven-plugin-test-kjar-8-modC-no-exec-model/pom.xml
@@ -31,7 +31,7 @@
   <parent>
     <artifactId>kie-maven-plugin-test-kjar-8-no-exec-model</artifactId>
     <groupId>org.kie</groupId>
-    <version>@org.kie.version@</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-8-no-exec-model/pom.xml
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-8-no-exec-model/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-maven-plugin-test-kjar-parent</artifactId>
-    <version>@org.kie.version@</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../kie-maven-plugin-test-kjar-setup/kie-maven-plugin-test-kjar-parent/pom.xml</relativePath>
   </parent>
 

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-9-exec-model/pom.xml
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-9-exec-model/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-maven-plugin-test-kjar-parent</artifactId>
-    <version>@org.kie.version@</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../kie-maven-plugin-test-kjar-setup/kie-maven-plugin-test-kjar-parent/pom.xml</relativePath>
   </parent>
 

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-9-no-exec-model/pom.xml
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-9-no-exec-model/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-maven-plugin-test-kjar-parent</artifactId>
-    <version>@org.kie.version@</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../kie-maven-plugin-test-kjar-setup/kie-maven-plugin-test-kjar-parent/pom.xml</relativePath>
   </parent>
 

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-setup/kie-maven-plugin-test-kjar-common/pom.xml
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-setup/kie-maven-plugin-test-kjar-common/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-maven-plugin-test-kjar-parent</artifactId>
-    <version>@org.kie.version@</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../kie-maven-plugin-test-kjar-parent/pom.xml</relativePath>
   </parent>
 

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-setup/kie-maven-plugin-test-kjar-parent/pom.xml
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-setup/kie-maven-plugin-test-kjar-parent/pom.xml
@@ -26,7 +26,7 @@
 
   <groupId>org.kie</groupId>
   <artifactId>kie-maven-plugin-test-kjar-parent</artifactId>
-  <version>@org.kie.version@</version>
+  <version>111-SNAPSHOT</version>
 
   <packaging>pom</packaging>
 

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-setup/pom.xml
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-setup/pom.xml
@@ -26,7 +26,7 @@
 
   <groupId>org.kie</groupId>
   <artifactId>kie-maven-plugin-test-kjar-setup</artifactId>
-  <version>@org.kie.version@</version>
+  <version>111-SNAPSHOT</version>
 
   <packaging>pom</packaging>
 

--- a/kie-memory-compiler/pom.xml
+++ b/kie-memory-compiler/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/kie-pmml-trusty/kie-pmml-api/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-api/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kie-pmml-trusty</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-commons/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-commons/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-trusty</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-api/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-api/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-compiler</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-commons/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-compiler</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-core/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-compiler/kie-pmml-compiler-core/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-compiler</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-compiler/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-compiler/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-trusty</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-dependencies/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-dependencies/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-trusty</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-api/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-api/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-evaluator</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-evaluator</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-utils/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-utils/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kie-pmml-evaluator</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-evaluator/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-evaluator/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-trusty</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-compiler/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-compiler/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-clustering</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-evaluator/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-evaluator/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-clustering</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-model/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-model/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-clustering</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-tests/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/kie-pmml-models-clustering-tests/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-clustering</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-clustering/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-common/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-drools</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-compiler/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-compiler/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-drools-scorecard</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-evaluator/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-evaluator/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-drools-scorecard</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-model/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-model/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-drools-scorecard</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-tests/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/kie-pmml-models-drools-scorecard-tests/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-drools-scorecard</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-scorecard/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-drools</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-compiler/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-drools-tree</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-evaluator/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-evaluator/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-drools-tree</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-model/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-model/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-drools-tree</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-tests/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/kie-pmml-models-drools-tree-tests/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-drools-tree</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/kie-pmml-models-drools-tree/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-drools</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-drools/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-compiler/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-mining</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-evaluator/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-evaluator/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-mining</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-model/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-model/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-mining</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/kie-pmml-models-mining-tests/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-mining</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-mining/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-compiler/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-regression</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-evaluator/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-evaluator/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-regression</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-model/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-model/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-regression</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/kie-pmml-models-regression-tests/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-regression</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-regression/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-compiler/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-compiler/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-scorecard</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-evaluator/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-evaluator/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-scorecard</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-model/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-model/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-scorecard</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-tests/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/kie-pmml-models-scorecard-tests/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-scorecard</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-scorecard/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tests/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tests/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kie-pmml-models</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-compiler/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-compiler/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-tree</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-evaluator/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-evaluator/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-tree</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-model/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-model/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-tree</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-tests/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/kie-pmml-models-tree-tests/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models-tree</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tree/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-models</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>

--- a/kie-pmml-trusty/kie-pmml-models/pom.xml
+++ b/kie-pmml-trusty/kie-pmml-models/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-pmml-trusty</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-pmml-trusty/pom.xml
+++ b/kie-pmml-trusty/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/kie-test-util/pom.xml
+++ b/kie-test-util/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/kie-util/kie-util-maven-integration/pom.xml
+++ b/kie-util/kie-util-maven-integration/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-util</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-util/kie-util-maven-support/pom.xml
+++ b/kie-util/kie-util-maven-support/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-util</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-util/kie-util-xml/pom.xml
+++ b/kie-util/kie-util-xml/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-util</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-util/pom.xml
+++ b/kie-util/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/kie-yard/kie-yard-api/pom.xml
+++ b/kie-yard/kie-yard-api/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-yard</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-yard-api</artifactId>

--- a/kie-yard/kie-yard-core/pom.xml
+++ b/kie-yard/kie-yard-core/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>kie-yard</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>kie-yard-core</artifactId>

--- a/kie-yard/pom.xml
+++ b/kie-yard/pom.xml
@@ -24,14 +24,14 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>drools-build-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
         <relativePath>../build-parent</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.kie</groupId>
     <artifactId>kie-yard</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>KIE :: Yard - YAML Rules DSL</name>

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,10 @@
   </description>
   <url>http://www.drools.org</url>
   <inceptionYear>2001</inceptionYear>
+  <organization>
+    <name>The Apache Software Foundation</name>
+    <url>https://apache.org/</url>
+  </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
   <groupId>org.kie</groupId>
   <artifactId>drools-parent</artifactId>
   <packaging>pom</packaging>
-  <version>999-SNAPSHOT</version>
+  <version>111-SNAPSHOT</version>
 
   <name>Drools :: Parent</name>
   <description>
@@ -84,7 +84,7 @@
     <repository>
       <id>central</id>
       <name>Central</name>
-      <url>https://repo1.maven.org/maven2/</url>
+      <url>https://repo.maven.apache.org/maven2/</url>
     </repository>
     <repository>
       <id>github</id>
@@ -106,7 +106,7 @@
     <pluginRepository>
       <id>central</id>
       <name>Central</name>
-      <url>https://repo1.maven.org/maven2/</url>
+      <url>https://repo.maven.apache.org/maven2/</url>
     </pluginRepository>
     <pluginRepository>
       <id>github</id>

--- a/pom.xml
+++ b/pom.xml
@@ -35,14 +35,10 @@
 
   <name>Drools :: Parent</name>
   <description>
-    The repo contains all code related to Drools project.
+    This repository is a fork of https://github.com/apache/incubator-kie-drools used for the purposes od SonataFlow.
   </description>
   <url>http://www.drools.org</url>
   <inceptionYear>2001</inceptionYear>
-  <organization>
-    <name>The Apache Software Foundation</name>
-    <url>https://apache.org/</url>
-  </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
@@ -52,9 +48,9 @@
   </licenses>
 
   <scm>
-    <connection>scm:git:https://github.com/apache/incubator-kie-drools.git</connection>
-    <developerConnection>scm:git:https://github.com/apache/incubator-kie-drools.git</developerConnection>
-    <url>https://github.com/apache/incubator-kie-drools</url>
+    <connection>scm:git:https://github.com/kiegroup/drools.git</connection>
+    <developerConnection>scm:git:https://github.com/kiegroup/drools.git</developerConnection>
+    <url>https://github.com/kiegroup/drools</url>
   </scm>
 
   <ciManagement>
@@ -65,57 +61,69 @@
     <system>GitHub Issues</system>
     <url>https://github.com/apache/incubator-kie-issues/issues</url>
   </issueManagement>
-  <developers>
-    <developer>
-      <name>The Apache KIE Team</name>
-      <email>dev@kie.apache.org</email>
-      <url>https://kie.apache.org</url>
-      <organization>Apache Software Foundation</organization>
-      <organizationUrl>http://apache.org/</organizationUrl>
-    </developer>
-  </developers>
-  <mailingLists>
-    <mailingList>
-      <name>Development List</name>
-      <subscribe>dev-subscribe@kie.apache.org</subscribe>
-      <unsubscribe>dev-unsubscribe@kie.apache.org</unsubscribe>
-      <post>dev@kie.apache.org</post>
-      <archive>https://lists.apache.org/list.html?dev@kie.apache.org</archive>
-    </mailingList>
-    <mailingList>
-      <name>User List</name>
-      <subscribe>users-subscribe@kie.apache.org</subscribe>
-      <unsubscribe>users-unsubscribe@kie.apache.org</unsubscribe>
-      <post>users@kie.apache.org</post>
-      <archive>https://lists.apache.org/list.html?users@kie.apache.org</archive>
-    </mailingList>
-    <mailingList>
-      <name>Commits List</name>
-      <subscribe>commits-subscribe@kie.apache.org</subscribe>
-      <unsubscribe>commits-unsubscribe@kie.apache.org</unsubscribe>
-      <post>commits@kie.apache.org</post>
-      <archive>https://lists.apache.org/list.html?commits@kie.apache.org</archive>
-    </mailingList>
-    <mailingList>
-      <name>setup</name>
-      <subscribe>https://groups.google.com/forum/#!forum/drools-setup</subscribe>
-      <unsubscribe>https://groups.google.com/forum/#!forum/drools-setup</unsubscribe>
-      <otherArchives>
-        <!-- Very old (and long deprecated) user mailing list -->
-        <otherArchive>http://drools.46999.n3.nabble.com/Drools-User-forum-f47000.html</otherArchive>
-      </otherArchives>
-    </mailingList>
-    <mailingList>
-      <name>usage</name>
-      <subscribe>https://groups.google.com/forum/#!forum/drools-usage</subscribe>
-      <unsubscribe>https://groups.google.com/forum/#!forum/drools-usage</unsubscribe>
-    </mailingList>
-  </mailingLists>
 
   <properties>
     <project.build.outputTimestamp>2024-01-12T00:00:00Z</project.build.outputTimestamp>
     <version.maven.artifact.plugin>3.4.1</version.maven.artifact.plugin>
   </properties>
+
+  <distributionManagement>
+    <repository>
+      <id>github</id>
+      <name>GitHub Packages</name>
+      <url>https://maven.pkg.github.com/kubesmarts/sonataflow-maven-repository</url>
+    </repository>
+    <snapshotRepository>
+      <id>github</id>
+      <name>GitHub Packages</name>
+      <url>https://maven.pkg.github.com/kubesmarts/sonataflow-maven-repository</url>
+    </snapshotRepository>
+  </distributionManagement>
+
+  <repositories>
+    <repository>
+      <id>central</id>
+      <name>Central</name>
+      <url>https://repo1.maven.org/maven2/</url>
+    </repository>
+    <repository>
+      <id>github</id>
+      <name>GitHub Repository</name>
+      <url>https://maven.pkg.github.com/kubesmarts/sonataflow-maven-repository</url>
+    </repository>
+    <repository>
+      <id>redhat-ga-repository</id>
+      <url>https://maven.repository.redhat.com/ga</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>central</id>
+      <name>Central</name>
+      <url>https://repo1.maven.org/maven2/</url>
+    </pluginRepository>
+    <pluginRepository>
+      <id>github</id>
+      <name>GitHub Repository</name>
+      <url>https://maven.pkg.github.com/kubesmarts/sonataflow-maven-repository</url>
+    </pluginRepository>
+    <pluginRepository>
+      <id>redhat-ga-plugin-repository</id>
+      <url>https://maven.repository.redhat.com/ga</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </pluginRepository>
+  </pluginRepositories>
 
   <build>
     <pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -163,35 +163,21 @@
     <module>drools-xml-support</module>
     <module>drools-legacy-test-util</module>
     <module>drools-tms</module>
-    <module>drools-beliefs</module>
     <module>drools-serialization-protobuf</module>
-    <module>drools-traits</module>
-    <module>drools-verifier</module>
-    <module>drools-persistence</module>
     <module>drools-templates</module>
     <module>drools-decisiontables</module>
-    <module>drools-examples</module>
     <module>kie-ci</module>
     <module>drools-model</module>
-    <module>drools-examples-api</module>
-    <module>drools-test-coverage</module>
-    <module>drools-scenario-simulation</module>
-    <module>drools-metric</module>
     <module>drools-alphanetwork-compiler</module>
     <module>drools-engine</module>
     <module>drools-engine-classic</module>
     <module>drools-impact-analysis</module>
-    <module>drools-retediagram</module>
-    <module>drools-fastutil</module>
     <module>efesto</module>
     <module>kie-drl</module>
     <module>kie-dmn</module>
     <module>kie-pmml-trusty</module>
-    <module>kie-maven-plugin</module>
-    <module>kie-archetypes</module>
     <module>drools-quarkus-extension</module>
     <module>drools-reliability</module>
-    <module>drools-drlonyaml-parent</module>
     <module>kie-yard</module>
   </modules>
 


### PR DESCRIPTION
Ticket: https://redhat.atlassian.net/browse/SRVLOGIC-963

Had to recreate this PR to get the latest changes from kogito-pipelines in PR checks. 

- Updates distributionManagement and repositories section.
- Changes 999-SNAPSHOT to 111-SNAPSHOT to distinct from Apache snapshots.
- Removed modules defined in the productized/modules directory from pom.xmls. (Basically the remove_modules.sh script was executed on this branch).

Related PRs:
https://github.com/kiegroup/kogito-runtimes/pull/177
https://github.com/kiegroup/kogito-examples/pull/108
https://github.com/kiegroup/kogito-apps/pull/120
https://github.com/kubesmarts/kie-tools/pull/301