### PR TITLE
[9.106.x-prod] Update netty to 4.1.137.Final. (#223)

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -74,7 +74,7 @@
     <version.info.picocli>4.7.7</version.info.picocli>
     <version.io.micrometer>1.16.6</version.io.micrometer>
     <version.io.quarkus>3.33.3</version.io.quarkus>
-    <version.io.netty>4.1.136.Final</version.io.netty>
+    <version.io.netty>4.1.137.Final</version.io.netty>
     <version.io.smallrye.openapi.core>4.2.4</version.io.smallrye.openapi.core>
     <version.io.smallrye.config.core>3.16.0</version.io.smallrye.config.core>
     <version.org.apache.kafka>4.1.2</version.org.apache.kafka>


### PR DESCRIPTION
Security backports from main from approx. the last week. 